### PR TITLE
fix: module not found for cjs import

### DIFF
--- a/src/services/mcp-tools.discovery.ts
+++ b/src/services/mcp-tools.discovery.ts
@@ -4,7 +4,7 @@ import { DiscoveryService, MetadataScanner } from "@nestjs/core";
 import { MCP_TOOL_METADATA_KEY, ToolMetadata } from "../decorators";
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
-import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError, Progress } from "@modelcontextprotocol/sdk/types";
+import { CallToolRequestSchema, ErrorCode, ListToolsRequestSchema, McpError, Progress } from "@modelcontextprotocol/sdk/types.js";
 
 export type Context = {
   reportProgress: (progress: Progress) => Promise<void>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "NodeNext",
     "declaration": true,
     "declarationMap": true,
     "removeComments": true,


### PR DESCRIPTION
Fix https://github.com/rekog-labs/MCP-Nest/issues/4

2 changes:

- Set tsconfig module resolution to NodeNext to detect the issue with import statement
  - And fix the issue