### PR TITLE
feat: add cleanup decorator and expose request object in tool context

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A NestJS module for exposing your services as an MCP (Model Context Protocol) se
 - **Tool Discovery**: Automatically discover and register tools using decorators
 - **Tool Request Validation**: Define Zod schemas to validate tool requests.
 - **Progress Notifications**: Send continuous progress updates from tools to clients.
+- **Cleanup**: Define resource cleanup logic when mcp session is closed using decorator
 
 ## Installation
 
@@ -42,9 +43,10 @@ export class AppModule {}
 ```typescript
 // greeting.tool.ts
 import { Injectable } from '@nestjs/common';
-import { Tool } from '@rekog/mcp-nest';
+import { Tool, Cleanup } from '@rekog/mcp-nest';
 import { z } from 'zod';
 import { Context } from '@rekog/mcp-nest/dist/services/mcp-tools.discovery';
+import { CleanupContext } from '@rekog/mcp-nest/dist/services/cleanup.service';
 import { Progress } from '@modelcontextprotocol/sdk/types';
 
 @Injectable()
@@ -60,6 +62,11 @@ export class GreetingTool {
     }),
   })
   async sayHello({ name }, context: Context) {
+    const { request } = context;
+
+    // retrieve unique session id of the current tool call
+    const sessionId = req.query.sessionId as string;
+
     const greeting = `Hello, ${name}!`;
 
     const totalSteps = 5;
@@ -77,6 +84,14 @@ export class GreetingTool {
       content: [{ type: 'text', text: greeting }],
     };
   }
+
+  @Cleanup()
+  async onSessionClose(context: CleanupContext) {
+
+    const sessionId = context.sessionId;
+    // cleanup resources on session close
+  }
+
 }
 ```
 

--- a/src/controllers/sse.controller.factory.ts
+++ b/src/controllers/sse.controller.factory.ts
@@ -5,6 +5,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { McpOptions } from '../interfaces';
 import { McpToolsDiscovery } from '../services/mcp-tools.discovery';
+import { CleanupService } from '../services/cleanup.service';
 
 
 export function createSseController(
@@ -19,6 +20,7 @@ export function createSseController(
     constructor(
       @Inject('MCP_OPTIONS') public readonly options: McpOptions,
       public readonly mcpToolsDiscovery: McpToolsDiscovery,
+      public readonly cleanupService: CleanupService,
     ) {}
 
     @Get(sseEndpoint)
@@ -36,8 +38,9 @@ export function createSseController(
 
       this.transports.set(sessionId, transport);
 
-      transport.onclose = () => {
+      mcpServer.server.onclose = () => {
         this.transports.delete(sessionId);
+        this.cleanupService.cleanup(sessionId);
       };
 
       await mcpServer.connect(transport);

--- a/src/decorators/cleanup.decorator.ts
+++ b/src/decorators/cleanup.decorator.ts
@@ -1,0 +1,6 @@
+import { SetMetadata } from "@nestjs/common";
+import { MCP_CLEANUP_METADATA_KEY } from "./constants";
+
+export const Cleanup = () => {
+  return SetMetadata(MCP_CLEANUP_METADATA_KEY, {});
+};

--- a/src/decorators/constants.ts
+++ b/src/decorators/constants.ts
@@ -1,1 +1,2 @@
 export const MCP_TOOL_METADATA_KEY = 'mcp:tool';
+export const MCP_CLEANUP_METADATA_KEY = 'mcp:cleanup';

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,2 +1,3 @@
 export * from './tool.decorator';
+export * from './cleanup.decorator';
 export * from './constants';

--- a/src/mcp.module.ts
+++ b/src/mcp.module.ts
@@ -5,6 +5,7 @@ import { McpOptions, McpAsyncOptions, McpOptionsFactory } from './interfaces/mcp
 
 import { createSseController } from './controllers/sse.controller.factory';
 import { McpToolsDiscovery } from './services/mcp-tools.discovery';
+import { CleanupService } from './services/cleanup.service';
 
 @Module({})
 export class McpModule {
@@ -36,6 +37,7 @@ export class McpModule {
           inject: ['MCP_OPTIONS'],
         },
         McpToolsDiscovery,
+        CleanupService,
       ],
       exports: ['MCP_SERVER'],
     };
@@ -62,6 +64,7 @@ export class McpModule {
           inject: ['MCP_OPTIONS'],
         },
         McpToolsDiscovery,
+        CleanupService,
       ],
       exports: ['MCP_SERVER'],
     };

--- a/src/services/cleanup.service.ts
+++ b/src/services/cleanup.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, OnApplicationBootstrap } from "@nestjs/common";
+import { DiscoveryService, MetadataScanner } from "@nestjs/core";
+import { MCP_CLEANUP_METADATA_KEY } from "../decorators";
+
+export type CleanupContext = {
+  sessionId: string;
+}
+
+@Injectable()
+export class CleanupService implements OnApplicationBootstrap {
+  private callbacks: Array<{
+    instance: any;
+    methodName: string;
+  }> = [];
+
+  constructor(
+    private readonly discovery: DiscoveryService,
+    private readonly metadataScanner: MetadataScanner,
+  ) {}
+
+  onApplicationBootstrap() {
+    this.collectCallbacks();
+  }
+
+  collectCallbacks() {
+    const providers = this.discovery.getProviders();
+    const controllers = this.discovery.getControllers();
+    const allInstances = [...providers, ...controllers]
+      .filter((wrapper) => wrapper.instance)
+      .map((wrapper) => wrapper.instance);
+
+    allInstances.forEach((instance) => {
+      if (!instance || typeof instance !== 'object') {
+        return;
+      }
+      this.metadataScanner.getAllMethodNames(instance).forEach((methodName) => {
+        const methodRef = instance[methodName];
+        const methodMetaKeys = Reflect.getOwnMetadataKeys(methodRef);
+
+        if (!methodMetaKeys.includes(MCP_CLEANUP_METADATA_KEY)) {
+          return;
+        }
+
+        this.callbacks.push({
+          instance,
+          methodName,
+        });
+      });
+    });
+  }
+
+  async cleanup(sessionId: string) {
+    return Promise.allSettled(
+      this.callbacks.map(
+        async ({instance, methodName}) => instance[methodName].call(
+          instance,
+          {
+            sessionId,
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/src/services/mcp-tools.discovery.ts
+++ b/src/services/mcp-tools.discovery.ts
@@ -14,6 +14,7 @@ export type Context = {
     info: (message: string, data?: SerializableValue) => void;
     warn: (message: string, data?: SerializableValue) => void;
   };
+  request: z.infer<typeof CallToolRequestSchema>;
 };
 
 type Literal = boolean | null | number | string | undefined;
@@ -149,10 +150,8 @@ export class McpToolsDiscovery implements OnApplicationBootstrap {
         parsedParams = result.data;
       }
 
-      const progressToken = request.params?._meta?.progressToken;
-
       try {
-        const context = this.createContext(mcpServer, progressToken!);
+        const context = this.createContext(mcpServer, request);
         const result = await tool.instance[tool.methodName].call(
           tool.instance,
           parsedParams,
@@ -186,7 +185,9 @@ export class McpToolsDiscovery implements OnApplicationBootstrap {
     });
   }
 
-  private createContext(mcpServer: McpServer, progressToken?: string | number) : Context {
+  private createContext(mcpServer: McpServer, request: z.infer<typeof CallToolRequestSchema>) : Context {
+    const progressToken = request.params?._meta?.progressToken;
+
     return {
       reportProgress: async (progress: Progress) => {
         if (progressToken) {
@@ -225,6 +226,7 @@ export class McpToolsDiscovery implements OnApplicationBootstrap {
           });
         },
       },
+      request,
     };
   }
 }


### PR DESCRIPTION
Add:
- Cleanup decorator for adding cleanup logic when MCP transport is closed

Update:
- add request object in Tool context to allow more flexibility when processing a tool call request

Fix:
- Bind onclose callback with mcp server instead of transport since transport.onclose will be taken over after `mcpServer.connect`