### PR TITLE
fix(sse): implement ping mechanism to prevent connection timeouts

### DIFF
--- a/src/interfaces/mcp-options.interface.ts
+++ b/src/interfaces/mcp-options.interface.ts
@@ -9,6 +9,10 @@ export interface McpOptions {
   globalApiPrefix?: string;
   capabilities?: Record<string, any>;
   guards?: Type<CanActivate>[];
+  sse?: {
+    pingEnabled?: boolean;
+    pingIntervalMs?: number;
+  };
 }
 
 export interface McpOptionsFactory {

--- a/src/mcp.module.ts
+++ b/src/mcp.module.ts
@@ -9,6 +9,7 @@ import {
 import { createSseController } from './controllers/sse.controller.factory';
 import { McpRegistryService } from './services/mcp-registry.service';
 import { McpExecutorService } from './services/mcp-executor.service';
+import { SsePingService } from './services/sse-ping.service';
 
 @Module({})
 export class McpModule {
@@ -35,11 +36,12 @@ export class McpModule {
           provide: 'MCP_OPTIONS',
           useValue: options,
         },
-        // Register both the registry (singleton) and executor (request-scoped) services
+        // Register services
         McpRegistryService,
         McpExecutorService,
+        SsePingService,
       ],
-      exports: [McpRegistryService, McpExecutorService],
+      exports: [McpRegistryService, McpExecutorService, SsePingService],
     };
   }
 
@@ -52,11 +54,12 @@ export class McpModule {
       controllers: [],
       providers: [
         ...providers,
-        // Register both the registry and executor services
+        // Register services
         McpRegistryService,
         McpExecutorService,
+        SsePingService,
       ],
-      exports: [McpRegistryService, McpExecutorService],
+      exports: [McpRegistryService, McpExecutorService, SsePingService],
     };
   }
 

--- a/src/services/sse-ping.service.ts
+++ b/src/services/sse-ping.service.ts
@@ -1,0 +1,136 @@
+import {
+  Injectable,
+  OnModuleInit,
+  OnModuleDestroy,
+  Logger,
+} from '@nestjs/common';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import type { Response } from 'express';
+
+/**
+ * Service that implements automatic ping for SSE connections
+ * This prevents browser/client timeouts for long-lived connections
+ */
+@Injectable()
+export class SsePingService implements OnModuleInit, OnModuleDestroy {
+  private pingInterval: NodeJS.Timeout | null = null;
+  private readonly logger = new Logger(SsePingService.name);
+  private readonly activeConnections = new Map<
+    string,
+    {
+      transport: SSEServerTransport;
+      res: Response;
+    }
+  >();
+
+  // Default to 30 seconds - this is a reasonable interval for most clients
+  private pingIntervalMs = 30000;
+
+  constructor() {}
+
+  onModuleInit() {
+    this.logger.log('Initializing SSE ping service');
+  }
+
+  onModuleDestroy() {
+    this.stopPingInterval();
+    this.logger.log('SSE ping service stopped');
+  }
+
+  /**
+   * Configure the ping service
+   */
+  configure(options: { pingEnabled?: boolean; pingIntervalMs?: number }) {
+    if (options.pingIntervalMs !== undefined) {
+      this.pingIntervalMs = options.pingIntervalMs;
+    }
+
+    if (options.pingEnabled !== false) {
+      this.startPingInterval();
+    } else {
+      this.stopPingInterval();
+    }
+  }
+
+  /**
+   * Register a new SSE connection to receive pings
+   */
+  registerConnection(
+    sessionId: string,
+    transport: SSEServerTransport,
+    res: Response,
+  ) {
+    this.activeConnections.set(sessionId, { transport, res });
+    this.logger.debug(`SSE connection registered: ${sessionId}`);
+  }
+
+  /**
+   * Remove an SSE connection
+   */
+  removeConnection(sessionId: string) {
+    this.activeConnections.delete(sessionId);
+    this.logger.debug(`SSE connection removed: ${sessionId}`);
+  }
+
+  /**
+   * Start the ping interval timer
+   */
+  private startPingInterval() {
+    if (this.pingInterval) {
+      this.stopPingInterval();
+    }
+
+    this.logger.log(
+      `Starting SSE ping service (interval: ${this.pingIntervalMs}ms)`,
+    );
+    this.pingInterval = setInterval(() => {
+      this.sendPingToAllConnections();
+    }, this.pingIntervalMs);
+  }
+
+  /**
+   * Stop the ping interval timer
+   */
+  private stopPingInterval() {
+    if (this.pingInterval) {
+      clearInterval(this.pingInterval);
+      this.pingInterval = null;
+      this.logger.log('SSE ping interval stopped');
+    }
+  }
+
+  /**
+   * Send a ping to all active connections
+   */
+  private sendPingToAllConnections() {
+    const timestamp = Date.now();
+    const connectionCount = this.activeConnections.size;
+
+    if (connectionCount === 0) {
+      return;
+    }
+
+    this.logger.debug(`Sending SSE ping to ${connectionCount} connections`);
+
+    for (const [sessionId, { res }] of this.activeConnections.entries()) {
+      try {
+        // Send a comment-type SSE message (line starting with ':')
+        // This keeps the connection alive without triggering an event in the client
+        if (!res.closed && res.writable) {
+          res.write(`: ping - ${new Date(timestamp).toISOString()}\n\n`);
+        } else {
+          this.logger.debug(
+            `Connection ${sessionId} is no longer writable, removing`,
+          );
+          this.removeConnection(sessionId);
+        }
+      } catch (error) {
+        this.logger.error(
+          `Error sending ping to connection ${sessionId}`,
+          error,
+        );
+        this.removeConnection(sessionId);
+      }
+    }
+  }
+}

--- a/src/services/sse-ping.service.ts
+++ b/src/services/sse-ping.service.ts
@@ -122,6 +122,8 @@ export class SsePingService implements OnModuleInit, OnModuleDestroy {
           this.logger.debug(
             `Connection ${sessionId} is no longer writable, removing`,
           );
+         // TODO: After non writable connections are discovered it'd be useful to cleanup transports/mcp servers
+         // for that connection in  sse.controller.factory.ts
           this.removeConnection(sessionId);
         }
       } catch (error) {


### PR DESCRIPTION
# SSE Connection Timeout Prevention

## Problem
Clients using Server-Sent Events (SSE) connections with MCP-Nest, particularly desktop agents like Cursor and VSCode, were experiencing `TypeError: terminated: Body Timeout Error` after periods of inactivity. This was causing unexpected disconnections and disrupting the user experience.

## Solution
This PR implements an automatic ping mechanism that sends periodic heartbeat messages to keep SSE connections alive during periods of inactivity:

- Created a new `SsePingService` that manages all active SSE connections
- Added configuration options in `McpOptions` to enable/disable pings and set interval
- Integrated the ping service with the SSE controller
- Implemented proper connection tracking and cleanup

The ping mechanism uses SSE comments (starting with `:`) which keep the HTTP connection alive without triggering event handlers in the client.

## Configuration
The ping functionality can be configured through the MCP module options:
```typescript
McpModule.forRoot({
  // ...
  sse: {
    pingEnabled: true,     // Default is true
    pingIntervalMs: 30000  // Default is 30 seconds
  }
})
```

## Testing
Tested with various clients and confirmed the fix resolves the timeout issues. Connections now remain stable even after extended periods of inactivity.

Closes #23