### PR TITLE
feat: add custom decorators support

### DIFF
--- a/src/controllers/custom-decorator.spec.ts
+++ b/src/controllers/custom-decorator.spec.ts
@@ -1,0 +1,75 @@
+import { SetMetadata } from '@nestjs/common';
+import { createSseController } from './sse.controller.factory';
+import { createStreamableHttpController } from './streamable-http.controller.factory';
+
+describe('Custom Decorators', () => {
+  // Custom decorator for testing
+  const testCustomDecorator = SetMetadata('test:decorator', true);
+
+  describe('SSE Controller Factory', () => {
+    it('should apply custom decorators to the SSE controller', () => {
+      // Arrange
+      const decorators = [testCustomDecorator];
+
+      // Act
+      const SseController = createSseController(
+        'test-sse-endpoint',
+        'test-messages-endpoint',
+        '/api',
+        [],
+        decorators,
+      );
+
+      // Assert
+      expect(SseController).toBeDefined();
+      expect(Reflect.getMetadata('test:decorator', SseController)).toBeTruthy();
+    });
+
+    it('should work without custom decorators', () => {
+      // Act
+      const SseController = createSseController(
+        'test-sse-endpoint',
+        'test-messages-endpoint',
+        '/api',
+      );
+
+      // Assert
+      expect(SseController).toBeDefined();
+      expect(
+        Reflect.getMetadata('test:decorator', SseController),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('Streamable HTTP Controller Factory', () => {
+    it('should apply custom decorators to the Streamable HTTP controller', () => {
+      // Arrange
+      const decorators = [testCustomDecorator];
+
+      // Act
+      const StreamableController = createStreamableHttpController(
+        'test-http-endpoint',
+        '/api',
+        [],
+        decorators,
+      );
+
+      // Assert
+      expect(StreamableController).toBeDefined();
+      expect(
+        Reflect.getMetadata('test:decorator', StreamableController),
+      ).toBeTruthy();
+    });
+
+    it('should work without custom decorators', () => {
+      // Act
+      const StreamableController = createStreamableHttpController(
+        'test-http-endpoint',
+        '/api',
+      );
+
+      // Assert
+      expect(StreamableController).toBeDefined();
+    });
+  });
+});

--- a/src/controllers/sse.controller.factory.ts
+++ b/src/controllers/sse.controller.factory.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   OnModuleInit,
   VERSION_NEUTRAL,
+  applyDecorators,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { CanActivate } from '@nestjs/common';
@@ -30,10 +31,12 @@ export function createSseController(
   messagesEndpoint: string,
   globalApiPrefix: string,
   guards: Type<CanActivate>[] = [],
+  decorators: ClassDecorator[] = [],
 ) {
   @Controller({
     version: VERSION_NEUTRAL,
   })
+  @applyDecorators(...decorators)
   class SseController implements OnModuleInit {
     // Note: Currently, storing transports and servers in memory makes this not viable for scaling out.
     // Redis can be used for this purpose, but considering that HTTP Streamable succeeds SSE then we can drop keeping this in memory.

--- a/src/controllers/streamable-http.controller.factory.ts
+++ b/src/controllers/streamable-http.controller.factory.ts
@@ -10,6 +10,7 @@ import {
   UseGuards,
   OnModuleInit,
   Logger,
+  applyDecorators,
 } from '@nestjs/common';
 import type { Request, Response } from 'express';
 import { CanActivate } from '@nestjs/common';
@@ -29,8 +30,10 @@ export function createStreamableHttpController(
   endpoint: string,
   globalApiPrefix: string,
   guards: Type<CanActivate>[] = [],
+  decorators: ClassDecorator[] = [],
 ) {
   @Controller()
+  @applyDecorators(...decorators)
   class StreamableHttpController implements OnModuleInit {
     public readonly logger = new Logger(StreamableHttpController.name);
     public transports: { [sessionId: string]: StreamableHTTPServerTransport } =

--- a/src/interfaces/mcp-options.interface.ts
+++ b/src/interfaces/mcp-options.interface.ts
@@ -17,6 +17,7 @@ export interface McpOptions {
   globalApiPrefix?: string;
   capabilities?: Record<string, any>;
   guards?: Type<CanActivate>[];
+  decorators?: ClassDecorator[];
   sse?: {
     pingEnabled?: boolean;
     pingIntervalMs?: number;

--- a/src/mcp.module.ts
+++ b/src/mcp.module.ts
@@ -34,6 +34,7 @@ export class McpModule {
     const guards = options.guards ?? [];
     const transportType = options.transport ?? McpTransportType.SSE;
     const controllers: Type<any>[] = [];
+    const decorators = options.decorators ?? [];
 
     if (
       transportType === McpTransportType.SSE ||
@@ -44,6 +45,7 @@ export class McpModule {
         messagesEndpoint,
         globalApiPrefix,
         guards,
+        decorators,
       );
       controllers.push(sseController);
     }
@@ -56,6 +58,7 @@ export class McpModule {
         mcpEndpoint,
         globalApiPrefix,
         guards,
+        decorators,
       );
       controllers.push(streamableHttpController);
     }


### PR DESCRIPTION

# feat: add custom decorators support

## Description
This PR adds support for applying custom decorators to dynamically created controllers. It enables users to apply additional metadata, validation, or other class-level decorators to both SSE and Streamable HTTP controllers.

## Changes
- Added optional `decorators` parameter to `createSseController` and `createStreamableHttpController` factory functions
- Updated `McpOptions` interface to include optional `decorators` property
- Applied decorators using NestJS `applyDecorators` utility
- Added comprehensive test coverage for the new functionality

## Benefits
- Increases flexibility when creating dynamic controllers
- Enables authentication, authorization, and other cross-cutting concerns to be applied through decorators
- Maintains backward compatibility with existing code

## Testing
Added unit tests to verify decorator application works as expected for both controller types.
