### PR TITLE
Adds support for stateless mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rekog/mcp-nest",
-  "version": "1.5.0-beta.0",
+  "version": "1.5.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rekog/mcp-nest",
-      "version": "1.5.0-beta.0",
+      "version": "1.5.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "path-to-regexp": "^8.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rekog/mcp-nest",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rekog/mcp-nest",
-      "version": "1.4.0",
+      "version": "1.5.0-beta.0",
       "license": "MIT",
       "dependencies": {
         "path-to-regexp": "^8.2.0"

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@rekog/mcp-nest",
-  "version": "1.5.0-beta.0",
-  "description": "NestJS module for creating Model Context Protocol (MCP) servers and exposing tools using SSE",
+  "version": "1.5.0-beta.1",
+  "description": "NestJS module for creating Model Context Protocol (MCP) servers",
   "main": "dist/index.js",
   "license": "MIT",
   "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rekog-labs/MCP-Nest"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rekog/mcp-nest",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.0",
   "description": "NestJS module for creating Model Context Protocol (MCP) servers and exposing tools using SSE",
   "main": "dist/index.js",
   "license": "MIT",

--- a/playground/http-streamable-client.ts
+++ b/playground/http-streamable-client.ts
@@ -58,6 +58,8 @@ async function main(): Promise<void> {
   // List and call tools
   await listTools(client);
 
+  await listTools(client);
+
   await callGreetTool(client);
   console.log(
     '\nKeeping connection open to receive notifications. Press Ctrl+C to exit.',

--- a/playground/server.ts
+++ b/playground/server.ts
@@ -13,7 +13,10 @@ import { GreetingTool } from './greeting.tool';
       version: '0.0.1',
       streamableHttp: {
         enableJsonResponse: true,
-        sessionIdGenerator: () => randomUUID(),
+        // For stateful mode (default):
+        sessionIdGenerator: undefined,
+        // Uncomment the line below to enable stateless mode:
+        statelessMode: true,
       },
       transport: McpTransportType.BOTH,
     }),

--- a/src/controllers/streamable-http.controller.factory.ts
+++ b/src/controllers/streamable-http.controller.factory.ts
@@ -1,27 +1,28 @@
 import {
   Body,
+  CanActivate,
   Controller,
+  Delete,
   Get,
   Inject,
+  Logger,
+  OnModuleInit,
   Post,
   Req,
   Res,
   Type,
   UseGuards,
-  OnModuleInit,
-  Logger,
   applyDecorators,
 } from '@nestjs/common';
-import type { Request, Response } from 'express';
-import { CanActivate } from '@nestjs/common';
 import { ContextIdFactory, ModuleRef } from '@nestjs/core';
 import { randomUUID } from 'crypto';
+import type { Request, Response } from 'express';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { McpOptions } from '../interfaces';
-import { McpRegistryService } from '../services/mcp-registry.service';
 import { McpExecutorService } from '../services/mcp-executor.service';
+import { McpRegistryService } from '../services/mcp-registry.service';
 
 /**
  * Creates a controller for handling Streamable HTTP connections and tool executions
@@ -40,15 +41,70 @@ export function createStreamableHttpController(
       {};
     public mcpServers: { [sessionId: string]: McpServer } = {};
 
+    // Singleton instances for stateless mode
+    public statelessTransport: StreamableHTTPServerTransport | null = null;
+    public statelessMcpServer: McpServer | null = null;
+    public isStatelessMode: boolean = false;
+
     constructor(
       @Inject('MCP_OPTIONS') public readonly options: McpOptions,
       public readonly moduleRef: ModuleRef,
       public readonly toolRegistry: McpRegistryService,
-    ) {}
+    ) {
+      // Determine if we're in stateless mode
+      this.isStatelessMode = !!options.streamableHttp?.statelessMode;
+
+      // Initialize stateless mode if needed
+      if (this.isStatelessMode) {
+        this.initializeStatelessMode()
+          .then(() => {
+            this.logger.debug('Stateless mode initialized');
+          })
+          .catch((error) => {
+            this.logger.error('Error initializing stateless mode:', error);
+          });
+      }
+    }
+
+    /**
+     * Initialize the stateless mode with singleton transport and server
+     */
+    public async initializeStatelessMode(): Promise<void> {
+      this.logger.log('Initializing MCP Streamable HTTP in stateless mode');
+
+      // Create a singleton transport for all requests
+      this.statelessTransport = new StreamableHTTPServerTransport({
+        // statelessMode: true, // TODO: Uncomment when this PR is merged and released: https://github.com/modelcontextprotocol/typescript-sdk/pull/362
+        sessionIdGenerator: () => undefined,
+        enableJsonResponse:
+          this.options.streamableHttp?.enableJsonResponse || false,
+      });
+
+      // TODO: Remove when this PR is merged and released: https://github.com/modelcontextprotocol/typescript-sdk/pull/362
+      (this.statelessTransport as any)._initialized = true;
+
+      // Create a singleton MCP server instance
+      this.statelessMcpServer = new McpServer(
+        { name: this.options.name, version: this.options.version },
+        {
+          capabilities: this.options.capabilities || {
+            tools: {},
+            resources: {},
+            resourceTemplates: {},
+            prompts: {},
+          },
+        },
+      );
+
+      // Connect the transport to the MCP server
+      await this.statelessMcpServer.connect(this.statelessTransport);
+    }
 
     onModuleInit() {
       this.logger.log(
-        `Initialized MCP Streamable HTTP controller at ${endpoint}`,
+        `Initialized MCP Streamable HTTP controller at ${endpoint} in ${
+          this.isStatelessMode ? 'stateless' : 'stateful'
+        } mode`,
       );
     }
 
@@ -65,97 +121,11 @@ export function createStreamableHttpController(
       this.logger.debug('Received MCP request:', body);
 
       try {
-        // Check for existing session ID
-        const sessionId = req.headers['mcp-session-id'] as string | undefined;
-        let transport: StreamableHTTPServerTransport;
-
-        if (sessionId && this.transports[sessionId]) {
-          // Reuse existing transport
-          transport = this.transports[sessionId];
-        } else if (!sessionId && this.isInitializeRequest(body)) {
-          // New initialization request
-          transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator:
-              this.options.streamableHttp?.sessionIdGenerator ||
-              (() => randomUUID()),
-            enableJsonResponse:
-              this.options.streamableHttp?.enableJsonResponse || false,
-          });
-
-          // Create a new MCP server for this session
-          const mcpServer = new McpServer(
-            { name: this.options.name, version: this.options.version },
-            {
-              capabilities: this.options.capabilities || {
-                tools: {},
-                resources: {},
-                resourceTemplates: {},
-                prompts: {},
-              },
-            },
-          );
-
-          // Connect the transport to the MCP server BEFORE handling the request
-          await mcpServer.connect(transport);
-
-          // Handle the initialization request
-          await transport.handleRequest(req, res, body);
-
-          // Store the transport and server by session ID for future requests
-          if (transport.sessionId) {
-            this.transports[transport.sessionId] = transport;
-            this.mcpServers[transport.sessionId] = mcpServer;
-
-            // Set up cleanup when connection closes
-            transport.onclose = () => {
-              this.cleanupSession(transport.sessionId!);
-            };
-          }
-
-          this.logger.log(
-            `Initialized new session with ID: ${transport.sessionId}`,
-          );
-          return; // Already handled
+        if (this.isStatelessMode) {
+          return this.handleStatelessRequest(req, res, body);
         } else {
-          // Invalid request - no session ID or not initialization request
-          res.status(400).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32000,
-              message: 'Bad Request: No valid session ID provided',
-            },
-            id: null,
-          });
-          return;
+          return this.handleStatefulRequest(req, res, body);
         }
-
-        // For subsequent requests to an existing session
-        const mcpServer = this.mcpServers[sessionId];
-        if (!mcpServer) {
-          res.status(404).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32000,
-              message: 'Session not found',
-            },
-            id: null,
-          });
-          return;
-        }
-
-        // Resolve the request-scoped tool executor service
-        const contextId = ContextIdFactory.getByRequest(req);
-        const executor = await this.moduleRef.resolve(
-          McpExecutorService,
-          contextId,
-          { strict: false },
-        );
-
-        // Register request handlers with the user context from this specific request
-        executor.registerRequestHandlers(mcpServer, req);
-
-        // Handle the request with existing transport
-        await transport.handleRequest(req, res, body);
       } catch (error) {
         this.logger.error('Error handling MCP request:', error);
         if (!res.headersSent) {
@@ -172,11 +142,143 @@ export function createStreamableHttpController(
     }
 
     /**
+     * Handle requests in stateless mode
+     */
+    public async handleStatelessRequest(
+      req: Request,
+      res: Response,
+      body: unknown,
+    ): Promise<void> {
+      if (!this.statelessTransport || !this.statelessMcpServer) {
+        await this.initializeStatelessMode();
+      }
+
+      // Resolve the request-scoped tool executor service
+      const contextId = ContextIdFactory.getByRequest(req);
+      const executor = await this.moduleRef.resolve(
+        McpExecutorService,
+        contextId,
+        { strict: false },
+      );
+
+      // Register request handlers with the user context from this specific request
+      executor.registerRequestHandlers(this.statelessMcpServer!, req);
+
+      // Handle the request with the singleton transport
+      await this.statelessTransport!.handleRequest(req, res, body);
+    }
+
+    /**
+     * Handle requests in stateful mode
+     */
+    public async handleStatefulRequest(
+      req: Request,
+      res: Response,
+      body: unknown,
+    ): Promise<void> {
+      // Check for existing session ID
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+      let transport: StreamableHTTPServerTransport;
+
+      if (sessionId && this.transports[sessionId]) {
+        // Reuse existing transport
+        transport = this.transports[sessionId];
+      } else if (!sessionId && this.isInitializeRequest(body)) {
+        // New initialization request
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator:
+            this.options.streamableHttp?.sessionIdGenerator ||
+            (() => randomUUID()),
+          enableJsonResponse:
+            this.options.streamableHttp?.enableJsonResponse || false,
+        });
+
+        // Create a new MCP server for this session
+        const mcpServer = new McpServer(
+          { name: this.options.name, version: this.options.version },
+          {
+            capabilities: this.options.capabilities || {
+              tools: {},
+              resources: {},
+              resourceTemplates: {},
+              prompts: {},
+            },
+          },
+        );
+
+        // Connect the transport to the MCP server BEFORE handling the request
+        await mcpServer.connect(transport);
+
+        // Handle the initialization request
+        await transport.handleRequest(req, res, body);
+
+        // Store the transport and server by session ID for future requests
+        if (transport.sessionId) {
+          this.transports[transport.sessionId] = transport;
+          this.mcpServers[transport.sessionId] = mcpServer;
+
+          // Set up cleanup when connection closes
+          transport.onclose = () => {
+            this.cleanupSession(transport.sessionId!);
+          };
+        }
+
+        this.logger.log(
+          `Initialized new session with ID: ${transport.sessionId}`,
+        );
+        return; // Already handled
+      } else {
+        // Invalid request - no session ID or not initialization request
+        res.status(400).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Bad Request: No valid session ID provided',
+          },
+          id: null,
+        });
+        return;
+      }
+
+      // For subsequent requests to an existing session
+      const mcpServer = this.mcpServers[sessionId];
+      if (!mcpServer) {
+        res.status(404).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32000,
+            message: 'Session not found',
+          },
+          id: null,
+        });
+        return;
+      }
+
+      // Resolve the request-scoped tool executor service
+      const contextId = ContextIdFactory.getByRequest(req);
+      const executor = await this.moduleRef.resolve(
+        McpExecutorService,
+        contextId,
+        { strict: false },
+      );
+
+      // Register request handlers with the user context from this specific request
+      executor.registerRequestHandlers(mcpServer, req);
+
+      // Handle the request with existing transport
+      await transport.handleRequest(req, res, body);
+    }
+
+    /**
      * GET endpoint for SSE streams
      */
     @Get(endpoint)
     @UseGuards(...guards)
     async handleGetRequest(@Req() req: Request, @Res() res: Response) {
+      if (this.isStatelessMode) {
+        return this.handleStatelessRequest(req, res, req.body);
+      }
+
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
 
       if (!sessionId || !this.transports[sessionId]) {
@@ -187,6 +289,31 @@ export function createStreamableHttpController(
       this.logger.debug(`Establishing SSE stream for session ${sessionId}`);
       const transport = this.transports[sessionId];
       await transport.handleRequest(req, res);
+    }
+
+    /**
+     * DELETE endpoint for terminating sessions
+     */
+    @Delete(endpoint)
+    @UseGuards(...guards)
+    async handleDeleteRequest(@Req() req: Request, @Res() res: Response) {
+      if (this.isStatelessMode) {
+        // In stateless mode, we don't have sessions to delete
+        res.status(200).end();
+        return;
+      }
+
+      const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+      if (!sessionId || !this.transports[sessionId]) {
+        res.status(400).send('Invalid or missing session ID');
+        return;
+      }
+
+      this.logger.debug(`Terminating session ${sessionId}`);
+      const transport = this.transports[sessionId];
+      await transport.handleRequest(req, res);
+      this.cleanupSession(sessionId);
     }
 
     // Helper function to detect initialize requests

--- a/src/interfaces/mcp-options.interface.ts
+++ b/src/interfaces/mcp-options.interface.ts
@@ -25,6 +25,7 @@ export interface McpOptions {
   streamableHttp?: {
     enableJsonResponse?: boolean;
     sessionIdGenerator?: () => string;
+    statelessMode?: boolean;
   };
 }
 


### PR DESCRIPTION
To test this, run the playground and then execute the curl command below:

```
$ npm run start:playground

$ curl -X POST http://localhost:3030/mcp \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{
    "jsonrpc": "2.0",
    "id": 3,
    "method": "tools/call",
    "params": {
      "name": "hello-world",
      "arguments": {
        "name": "NestJS Developer"
      }
    }
  }'
```

This shows that requests are resolved directly and there is no need to initialize and maintain state.

This is still not production-ready, it requires more testing to make sure we support all our other features, but it is a good point to test and build on top of this. Additionally, I want to get some confirmation that this change is in line with the idea of this transport implementation (see PR: https://github.com/modelcontextprotocol/typescript-sdk/pull/362)

You can try it out on the latest beta build:

```
npm i @rekog/mcp-nest@1.5.0-beta.0
```