### PR TITLE
feat: adding new stdio for standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A NestJS module to effortlessly expose tools, resources, and prompts for AI, fro
 
 ## Features
 
-- 🚀 HTTP+SSE and Streamable HTTP Transport
+- 🚀 HTTP+SSE, Streamable HTTP, and STDIO Transport
 - 🔍 Automatic `tool`, `resource`, and `prompt` discovery and registration
 - 💯 Zod-based request validation
 - 📊 Progress notifications
@@ -29,7 +29,7 @@ A NestJS module to effortlessly expose tools, resources, and prompts for AI, fro
 npm install @rekog/mcp-nest @modelcontextprotocol/sdk zod
 ```
 
-## Quick Start
+## Quick Start for HTTP+SSE
 
 ### 1. Import Module
 
@@ -114,6 +114,31 @@ export class GreetingTool {
 
 You are done!
 
+## Quick Start for STDIO
+
+The main difference is that you need to provide the `transport` option when importing the module.
+
+```typescript
+McpModule.forRoot({
+  name: 'my-mcp-server',
+  version: '1.0.0',
+  transport: McpTransportType.STDIO,
+});
+```
+
+The rest is the same, you can define tools, resources, and prompts as usual. An example of a standalone NestJS application using the STDIO transport is the following:
+
+```typescript
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  return app.close();
+}
+
+void bootstrap();
+```
+
+Easy. Now you can access using a MCP Stdio Client.
+
 ## API Endpoints
 
 - `GET /sse`: SSE connection endpoint (Protected by guards if configured)
@@ -182,8 +207,8 @@ import { McpModule } from '@rekog/mcp-nest';
       name: 'my-mcp-server',
       version: '1.0.0',
       sse: {
-        pingEnabled: true,        // Default is true
-        pingIntervalMs: 30000,    // Default is 30 seconds (30000ms)
+        pingEnabled: true, // Default is true
+        pingIntervalMs: 30000, // Default is 30 seconds (30000ms)
       },
     }),
   ],

--- a/playground/README.md
+++ b/playground/README.md
@@ -23,3 +23,11 @@ Streamable HTTP is still not supported in the MCP Inspector and has to be tried 
 ```sh
 npx tsx playground/http-streamable-client.ts
 ```
+
+### Trying out with STDIO client
+
+Currently, the MCP STDIO client is supported, but multiple args are not so easy to handle in the inspector. To make testing easier, you can run the following command:
+
+```sh
+npx ts-node-dev --respawn ./playground/stdio-client.ts
+```

--- a/playground/stdio-client.ts
+++ b/playground/stdio-client.ts
@@ -1,0 +1,95 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+  CallToolRequest,
+  CallToolResultSchema,
+  ListPromptsRequest,
+  ListPromptsResultSchema,
+  ListToolsRequest,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+async function main(): Promise<void> {
+  // Create a new client with streamable HTTP transport
+  const client = new Client({
+    name: 'example-client',
+    version: '1.0.0',
+  });
+
+  const transport = new StdioClientTransport({
+    command: 'ts-node-dev',
+    args: ['--respawn', 'playground/stdio.ts'],
+  });
+
+  // Connect the client using the transport and initialize the server
+  await client.connect(transport);
+  console.log('Connected to MCP server stdio');
+
+  // List and call tools
+  await listTools(client);
+
+  await callGreetTool(client);
+
+  await listPrompts(client);
+}
+
+async function listTools(client: Client): Promise<void> {
+  try {
+    const toolsRequest: ListToolsRequest = {
+      method: 'tools/list',
+      params: {},
+    };
+    const toolsResult = await client.request(
+      toolsRequest,
+      ListToolsResultSchema,
+    );
+    console.log('Available tools: ', toolsResult.tools);
+    if (toolsResult.tools.length === 0) {
+      console.log('No tools available from the server');
+    }
+  } catch (error) {
+    console.log(`Tools not supported by this server (${error})`);
+    return;
+  }
+}
+
+async function listPrompts(client: Client): Promise<void> {
+  try {
+    const promptsRequest: ListPromptsRequest = {
+      method: 'prompts/list',
+      params: {},
+    };
+    const promptsResult = await client.request(
+      promptsRequest,
+      ListPromptsResultSchema,
+    );
+    console.log('Available prompts: ', promptsResult.prompts);
+  } catch (error) {
+    console.log(`Prompts not supported by this server (${error})`);
+    return;
+  }
+}
+
+async function callGreetTool(client: Client): Promise<void> {
+  try {
+    const greetRequest: CallToolRequest = {
+      method: 'tools/call',
+      params: {
+        name: 'hello-world',
+        arguments: { name: 'MCP User' },
+      },
+    };
+    const greetResult = await client.request(
+      greetRequest,
+      CallToolResultSchema,
+    );
+    console.log('Greeting result:', greetResult.content[0].text);
+  } catch (error) {
+    console.log(`Error calling greet tool: ${error}`);
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error('Error running MCP client:', error);
+  process.exit(1);
+});

--- a/playground/stdio.ts
+++ b/playground/stdio.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { McpModule, McpTransportType } from '../src';
+import { GreetingTool } from './greeting.tool';
+import { GreetingResource } from './greeting.resource';
+import { GreetingPrompt } from './greeting.prompt';
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'playground-stdio-server',
+      version: '0.0.1',
+      transport: McpTransportType.STDIO,
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+    }),
+  ],
+  providers: [GreetingTool, GreetingPrompt, GreetingResource],
+})
+class AppModule {}
+
+async function bootstrap() {
+  const app = await NestFactory.createApplicationContext(AppModule);
+  return app.close();
+}
+
+void bootstrap();

--- a/src/controllers/stdio.controller.factory.ts
+++ b/src/controllers/stdio.controller.factory.ts
@@ -1,0 +1,62 @@
+import {
+  Controller,
+  Inject,
+  Logger,
+  OnApplicationBootstrap,
+} from '@nestjs/common';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpOptions } from '../interfaces';
+import { McpRegistryService } from '../services/mcp-registry.service';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { McpExecutorService } from '../services/mcp-executor.service';
+
+/**
+ * Creates a controller for handling Streamable HTTP connections and tool executions
+ */
+export function createStdioController() {
+  @Controller()
+  class StdioController implements OnApplicationBootstrap {
+    public readonly logger = new Logger(StdioController.name);
+
+    constructor(
+      @Inject('MCP_OPTIONS') public readonly options: McpOptions,
+      public readonly toolRegistry: McpRegistryService,
+      public readonly moduleRef: ModuleRef,
+    ) {}
+
+    async onApplicationBootstrap() {
+      this.logger.log(`Initialized MCP STDIO controller`);
+
+      const mcpServer = new McpServer(
+        { name: this.options.name, version: this.options.version },
+        {
+          capabilities: this.options.capabilities || {
+            tools: {},
+            resources: {},
+            resourceTemplates: {},
+            prompts: {},
+          },
+        },
+      );
+
+      const contextId = ContextIdFactory.create();
+      const executorService = await this.moduleRef.resolve(
+        McpExecutorService,
+        contextId,
+        {
+          strict: false,
+        },
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      executorService.registerRequestHandlers(mcpServer, {} as any);
+
+      const transport = new StdioServerTransport();
+
+      await mcpServer.connect(transport);
+    }
+  }
+
+  return StdioController;
+}

--- a/src/interfaces/mcp-options.interface.ts
+++ b/src/interfaces/mcp-options.interface.ts
@@ -4,7 +4,9 @@ import { CanActivate } from '@nestjs/common';
 export enum McpTransportType {
   SSE = 'sse',
   STREAMABLE_HTTP = 'streamable-http',
+  // TODO: change name since now we have stdio
   BOTH = 'both',
+  STDIO = 'stdio',
 }
 
 export interface McpOptions {

--- a/src/mcp.module.ts
+++ b/src/mcp.module.ts
@@ -6,6 +6,7 @@ import { McpOptions, McpTransportType } from './interfaces';
 import { McpExecutorService } from './services/mcp-executor.service';
 import { McpRegistryService } from './services/mcp-registry.service';
 import { SsePingService } from './services/sse-ping.service';
+import { createStdioController } from './controllers/stdio.controller.factory';
 
 @Module({
   imports: [DiscoveryModule],
@@ -58,6 +59,11 @@ export class McpModule {
         guards,
       );
       controllers.push(streamableHttpController);
+    }
+
+    if (transportType === McpTransportType.STDIO) {
+      const stdioController = createStdioController();
+      controllers.push(stdioController);
     }
 
     return controllers;

--- a/src/services/handlers/mcp-handler.base.ts
+++ b/src/services/handlers/mcp-handler.base.ts
@@ -8,7 +8,10 @@ import {
   Progress,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { Context, SerializableValue } from 'src/interfaces/mcp-tool.interface';
+import {
+  Context,
+  SerializableValue,
+} from '../../interfaces/mcp-tool.interface';
 import { McpRegistryService } from '../mcp-registry.service';
 
 export abstract class McpHandlerBase {

--- a/src/services/mcp-registry.service.ts
+++ b/src/services/mcp-registry.service.ts
@@ -10,9 +10,9 @@ import {
   MCP_TOOL_METADATA_KEY,
   ToolMetadata,
 } from '../decorators';
-import { ResourceMetadata } from 'src/decorators/resource.decorator';
+import { ResourceMetadata } from '../decorators/resource.decorator';
 import { match } from 'path-to-regexp';
-import { PromptMetadata } from 'src/decorators/prompt.decorator';
+import { PromptMetadata } from '../decorators/prompt.decorator';
 
 /**
  * Interface representing a discovered tool


### PR DESCRIPTION
Adding new `standalone` support. To accomplish it:
- We need a new controller to handle the new `mcp server` using the `stdio transport`
- Added related documentation

<img width="895" alt="image" src="https://github.com/user-attachments/assets/24ae7219-67f2-4b54-ab78-3c9c3bd5c4c5" />

