### PR TITLE
Pass `sessionIdGenerator` as `undefined` for stateless mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
-        "@modelcontextprotocol/sdk": "^1.10.0",
+        "@modelcontextprotocol/sdk": "^1.10.2",
         "@nestjs/common": "^11.0.5",
         "@nestjs/core": "^11.0.5",
         "@nestjs/platform-express": "^11.0.5",
@@ -1299,10 +1299,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "name": "mcp-test-sdk",
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/mcp-test-sdk/-/mcp-test-sdk-1.10.0.tgz",
-      "integrity": "sha512-Prf9kU1WHLVu2Kfm1hHXy0YJcQngAvG34ZtADhSvt9VHnT4P91U0nZbb5RRaybqPszfnW1BKktUm+hxnz+Kt3w==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.10.2.tgz",
+      "integrity": "sha512-rb6AMp2DR4SN+kc6L1ta2NCpApyA9WYNx3CrTSZvGxq9wH71bRur+zRqPfg0vQ9mjywR7qZdX2RGHOPq3ss+tA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
-    "@modelcontextprotocol/sdk": "^1.10.0",
+    "@modelcontextprotocol/sdk": "^1.10.2",
     "@nestjs/common": "^11.0.5",
     "@nestjs/core": "^11.0.5",
     "@nestjs/platform-express": "^11.0.5",

--- a/src/transport/streamable-http.controller.factory.ts
+++ b/src/transport/streamable-http.controller.factory.ts
@@ -76,7 +76,7 @@ export function createStreamableHttpController(
       // Create a singleton transport for all requests
       this.statelessTransport = new StreamableHTTPServerTransport({
         // statelessMode: true, // TODO: Uncomment when this PR is merged and released: https://github.com/modelcontextprotocol/typescript-sdk/pull/362
-        sessionIdGenerator: () => undefined,
+        sessionIdGenerator: undefined,
         enableJsonResponse:
           this.options.streamableHttp?.enableJsonResponse || false,
       });


### PR DESCRIPTION
For this to work correctly, we cannot pass a callable even if it returns undefined

https://github.com/modelcontextprotocol/typescript-sdk/blob/747369476ae618b28bf8b6df0b33109dc10f4ad6/src/server/streamableHttp.ts#L466