### PR TITLE
Add zod to peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@nestjs/common": ">=9.0.0",
     "@nestjs/core": ">=9.0.0",
     "express": ">=4.0.0",
-    "reflect-metadata": ">=0.1.14"
+    "reflect-metadata": ">=0.1.14",
+    "zod": ">=3.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
`zod` is currently missing from peerDependencies, which causes an error for apps built with Bazel.

Error message:
```
Test suite failed to run

    Cannot find module 'zod' from '../../../node_modules/.aspect_rules_js/@rekog+mcp-nest@1.5.0_1282953668/node_modules/@rekog/mcp-nest/dist/decorators/tool.decorator.js'
```