### PR TITLE
Add support for InMemoryTransport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './interfaces';
 export * from './mcp.module';
 export * from './services/mcp-registry.service';
 export * from './services/mcp-executor.service';
+export * from './services/mcp-client.service';

--- a/src/interfaces/mcp-options.interface.ts
+++ b/src/interfaces/mcp-options.interface.ts
@@ -5,6 +5,7 @@ export enum McpTransportType {
   SSE = 'sse',
   STREAMABLE_HTTP = 'streamable-http',
   STDIO = 'stdio',
+  IN_MEMORY = 'in-memory',
 }
 
 export interface McpOptions {

--- a/src/mcp.module.ts
+++ b/src/mcp.module.ts
@@ -7,6 +7,7 @@ import { SsePingService } from './services/sse-ping.service';
 import { createSseController } from './transport/sse.controller.factory';
 import { StdioService } from './transport/stdio.service';
 import { createStreamableHttpController } from './transport/streamable-http.controller.factory';
+import { InMemoryService } from './transport/in-memory.service';
 
 @Module({
   imports: [DiscoveryModule],
@@ -19,6 +20,7 @@ export class McpModule {
         McpTransportType.SSE,
         McpTransportType.STREAMABLE_HTTP,
         McpTransportType.STDIO,
+        McpTransportType.IN_MEMORY,
       ],
       sseEndpoint: 'sse',
       messagesEndpoint: 'messages',
@@ -87,6 +89,10 @@ export class McpModule {
       // STDIO transport is handled by injectable StdioService, no controller
     }
 
+    if (transports.includes(McpTransportType.IN_MEMORY)) {
+      // IN_MEMORY transport is handled by injectable InMemoryService, no controller
+    }
+
     return controllers;
   }
 
@@ -110,6 +116,10 @@ export class McpModule {
 
     if (transports.includes(McpTransportType.STDIO)) {
       providers.push(StdioService);
+    }
+
+    if (transports.includes(McpTransportType.IN_MEMORY)) {
+      providers.push(InMemoryService);
     }
 
     return providers;

--- a/src/services/mcp-client.service.ts
+++ b/src/services/mcp-client.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryService } from '../transport/in-memory.service';
+
+/**
+ * Service that provides access to the MCP client.
+ * This service can be injected in other modules to get access to the MCP client.
+ */
+@Injectable()
+export class McpClientService {
+  constructor(private readonly inMemoryService: InMemoryService) {}
+
+  /**
+   * Get the MCP client instance.
+   * @returns The MCP client instance
+   * @throws Error if the client is not initialized or transport isn't IN_MEMORY
+   */
+  getClient(): Client {
+    if (!this.inMemoryService) {
+      throw new Error(
+        'InMemoryService is not available. Make sure the transport includes IN_MEMORY and McpModule is properly imported.',
+      );
+    }
+    return this.inMemoryService.client;
+  }
+}

--- a/src/transport/in-memory.service.ts
+++ b/src/transport/in-memory.service.ts
@@ -1,0 +1,70 @@
+import { Injectable, Inject, Logger, OnModuleInit } from '@nestjs/common';
+import { ModuleRef, ContextIdFactory } from '@nestjs/core';
+import { McpOptions, McpTransportType } from '../interfaces';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpExecutorService } from '../services/mcp-executor.service';
+
+@Injectable()
+export class InMemoryService implements OnModuleInit {
+  private readonly logger = new Logger(InMemoryService.name);
+
+  #client: Client | null = null;
+
+  constructor(
+    @Inject('MCP_OPTIONS') private readonly options: McpOptions,
+    private readonly moduleRef: ModuleRef,
+  ) {}
+
+  async onModuleInit() {
+    if (this.options.transport !== McpTransportType.IN_MEMORY) {
+      return;
+    }
+    this.logger.log('Bootstrapping MCP IN_MEMORY...');
+
+    const mcpServer = new McpServer(
+      { name: this.options.name, version: this.options.version },
+      {
+        capabilities: this.options.capabilities || {
+          tools: {},
+          resources: {},
+          prompts: {},
+          instructions: [],
+        },
+      },
+    );
+
+    const contextId = ContextIdFactory.create();
+    const executor = await this.moduleRef.resolve(
+      McpExecutorService,
+      contextId,
+      { strict: false },
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+    executor.registerRequestHandlers(mcpServer, {} as any);
+
+    const [serverTransport, clientTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    await mcpServer.connect(serverTransport);
+
+    this.#client = new Client({
+      name: `${this.options.name} client`,
+      version: this.options.version,
+    });
+
+    await this.#client.connect(clientTransport);
+
+    this.logger.log('MCP IN_MEMORY ready');
+  }
+
+  get client(): Client {
+    if (!this.#client) {
+      throw new Error('MCP Client is not initialized');
+    }
+
+    return this.#client;
+  }
+}


### PR DESCRIPTION
This pull request adds support for the (undocumented) [InMemoryTransport](https://github.com/modelcontextprotocol/typescript-sdk/blob/621ccea997bf318ee99c7f64ce19609e838615fa/src/inMemory.ts#L13).

My use case for this behavior is using the MCP server within the same process that is facilitating the communication with the LLM, such as running a custom chat server. When initialized with `McpTransportType.IN_MEMORY`, the `McpClientService` would enable a separate service (such as one used in a websocket gateway) to access the MCP server as a client


Here is a quick example of how this might be used:

```typescript
//chat.module.ts

@Module({
  imports: [
    McpModule.forRoot({
      name: 'my-mcp-server',
      version: '1.0.0',
      transport: McpTransportType.IN_MEMORY,
    }),
  ],
  providers: [
    ChatService,
    // ChatGateway, ...
  ],
})
export class ChatModule {}
```

```typescript
//chat.service.ts

@Injectable()
export class ChatService {
  constructor(
    private readonly mcpClientService: McpClientService,
  ) {}

  // ... other llm related calls

  async getTools() {
    return this.mcpClientService.getClient().listTools().catch((error) => {
      throw error;
    });
  }

  async callTool(
    toolName: string,
    params: any
  ) {
    return this.mcpClientService.getClient()
      .callTool({
        name: toolName,
        arguments: params,
      })
      .catch((error) => {
        throw error;
      });
  }
}
```

I'll open this as a draft to get some feedback first. This also still needs a test whipped up for it.

Thanks for the great nestjs package, I was working on something almost identical before I found this one! 