### PR TITLE
Add zod-to-json-schema to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "@nestjs/core": ">=9.0.0",
     "express": ">=4.0.0",
     "reflect-metadata": ">=0.1.14",
-    "zod": ">=3.0.0"
+    "zod": ">=3.0.0",
+    "zod-to-json-schema": ">=3.23.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",


### PR DESCRIPTION
Similar to the previous PR: https://github.com/rekog-labs/MCP-Nest/pull/48

zod-to-json-schema is missing in peer dependencies as well. Adding it.