### PR TITLE
Honor globalApiPrefix in Stremable HTTP Controller

### DIFF
--- a/src/transport/streamable-http.controller.factory.ts
+++ b/src/transport/streamable-http.controller.factory.ts
@@ -112,7 +112,7 @@ export function createStreamableHttpController(
     /**
      * Main HTTP endpoint for both initialization and subsequent requests
      */
-    @Post(endpoint)
+    @Post(`${globalApiPrefix}/${endpoint}`.replace(/\/+/g, '/'))
     @UseGuards(...guards)
     async handlePostRequest(
       @Req() req: Request,


### PR DESCRIPTION
`globalApiPrefix` option was not being honored in the Streamable HTTP Controller. 
Replicate the same logic in the SSE Controller to the Streamable HTTP controller.