### PR TITLE
Scope discovery to subtree of module that imports McpServer

### DIFF
--- a/src/services/mcp-executor.service.ts
+++ b/src/services/mcp-executor.service.ts
@@ -1,5 +1,5 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { Injectable, Logger, Scope } from '@nestjs/common';
+import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 import { Request } from 'express';
 import { McpRegistryService } from './mcp-registry.service';
@@ -17,10 +17,22 @@ export class McpExecutorService {
   private resourcesHandler: McpResourcesHandler;
   private promptsHandler: McpPromptsHandler;
 
-  constructor(moduleRef: ModuleRef, registry: McpRegistryService) {
-    this.toolsHandler = new McpToolsHandler(moduleRef, registry);
-    this.resourcesHandler = new McpResourcesHandler(moduleRef, registry);
-    this.promptsHandler = new McpPromptsHandler(moduleRef, registry);
+  constructor(
+    moduleRef: ModuleRef,
+    registry: McpRegistryService,
+    @Inject('MCP_MODULE_ID') mcpModuleId: string,
+  ) {
+    this.toolsHandler = new McpToolsHandler(moduleRef, registry, mcpModuleId);
+    this.resourcesHandler = new McpResourcesHandler(
+      moduleRef,
+      registry,
+      mcpModuleId,
+    );
+    this.promptsHandler = new McpPromptsHandler(
+      moduleRef,
+      registry,
+      mcpModuleId,
+    );
   }
 
   /**

--- a/src/services/mcp-registry.service.spec.ts
+++ b/src/services/mcp-registry.service.spec.ts
@@ -1,9 +1,18 @@
+import {
+  DynamicModule,
+  Injectable,
+  Module,
+  ValueProvider,
+} from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { McpRegistryService } from './mcp-registry.service';
 import { DiscoveryService, MetadataScanner } from '@nestjs/core';
+import { Tool } from '../decorators/tool.decorator';
+import { McpModule } from '../mcp.module';
 
 describe('McpRegistryService', () => {
   let service: McpRegistryService;
+  const mockMcpModuleId = 'test-mcp-module-id';
 
   const mockResource = (name: string, uri: string) => ({
     type: 'resource',
@@ -28,40 +37,232 @@ describe('McpRegistryService', () => {
     }).compile();
 
     service = module.get<McpRegistryService>(McpRegistryService);
-    (service as any).discoveredTools = [
+
+    const mockResources = [
       mockResource('res0', '/posts/comments'),
       mockResource('res1', '/users/{id}'),
       mockResource('res2', '/posts/:postId/comments'),
       mockResource('res3', 'mcp://hello-world'),
     ];
+
+    (service as any).discoveredToolsByMcpModuleId = new Map([
+      [mockMcpModuleId, mockResources],
+    ]);
   });
 
   it('should return the correct resource by URI', () => {
-    const result = service.findResourceByUri('/users/123');
+    const result = service.findResourceByUri(mockMcpModuleId, '/users/123');
+    expect(result?.resource.metadata.name).toBe('res1');
+    expect(result?.params).toEqual({ id: '123' });
+  });
+
+  it('should return the correct resource by URI', () => {
+    const result = service.findResourceByUri(mockMcpModuleId, '/users/123');
     expect(result?.resource.metadata.name).toBe('res1');
     expect(result?.params).toEqual({ id: '123' });
   });
 
   it('should return undefined for unknown URI', () => {
-    const result = service.findResourceByUri('/unknown/path');
+    const result = service.findResourceByUri(mockMcpModuleId, '/unknown/path');
     expect(result).toBeUndefined();
   });
 
   it('should match complex URI template', () => {
-    const result = service.findResourceByUri('/posts/456/comments');
+    const result = service.findResourceByUri(
+      mockMcpModuleId,
+      '/posts/456/comments',
+    );
     expect(result?.resource.metadata.name).toBe('res2');
     expect(result?.params).toEqual({ postId: '456' });
   });
 
   it('should match simple URI template', () => {
-    const result = service.findResourceByUri('/posts/comments');
+    const result = service.findResourceByUri(
+      mockMcpModuleId,
+      '/posts/comments',
+    );
     expect(result?.resource.metadata.name).toBe('res0');
     expect(result?.params).toEqual({});
   });
 
   it('should match mcp URI', () => {
-    const result = service.findResourceByUri('mcp://hello-world');
+    const result = service.findResourceByUri(
+      mockMcpModuleId,
+      'mcp://hello-world',
+    );
     expect(result?.resource.metadata.name).toBe('res3');
     expect(result?.params).toEqual({});
   });
 });
+
+/**
+ * In the case of multiple MCP servers in different modules, the discovery should be scoped to each MCP root.
+ * The structure of test modules is the following:
+ *
+ *                        TestModule
+ *                     /              \
+ *                   /                 \
+ *                 /                    \
+ *         ModuleA (server-a)     ModuleB (server-b)
+ *               |                      |
+ *               |                      |
+ *             ToolsA                 ToolsB
+ */
+describe('McpRegistryService - Multiple discovery roots', () => {
+  const mcpModuleA = McpModule.forRoot({ name: 'server-a', version: '0.0.1' });
+  const mcpModuleB = McpModule.forRoot({ name: 'server-b', version: '0.0.1' });
+
+  @Injectable()
+  class ToolsA {
+    @Tool({
+      name: 'toolA',
+      description: 'Tool A from ModuleA',
+    })
+    toolA() {
+      return 'Tool A result';
+    }
+  }
+
+  @Injectable()
+  class ToolsB {
+    @Tool({
+      name: 'toolB',
+      description: 'Tool B from ModuleB',
+    })
+    toolB() {
+      return 'Tool B result';
+    }
+  }
+
+  @Module({
+    imports: [mcpModuleA],
+    providers: [ToolsA],
+    exports: [ToolsA],
+  })
+  class ModuleA {}
+
+  @Module({
+    imports: [mcpModuleB],
+    providers: [ToolsB],
+    exports: [ToolsB],
+  })
+  class ModuleB {}
+
+  let service: McpRegistryService;
+  const idModuleA = getMcpModuleId(mcpModuleA);
+  const idModuleB = getMcpModuleId(mcpModuleB);
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [ModuleA, ModuleB],
+    }).compile();
+
+    service = module.get<McpRegistryService>(McpRegistryService);
+    service.onApplicationBootstrap();
+  });
+
+  it('server-a discovered toolA only', () => {
+    const tools = service.getTools(idModuleA);
+
+    expect(tools.length).toBe(1);
+
+    const tool = tools.find((tool) => tool.metadata.name === 'toolA');
+    expect(tool).toBeDefined();
+  });
+
+  it('server-b discovered toolB only', () => {
+    const tools = service.getTools(idModuleB);
+
+    expect(tools.length).toBe(1);
+
+    const tool = tools.find((tool) => tool.metadata.name === 'toolB');
+    expect(tool).toBeDefined();
+  });
+});
+
+/**
+ * In the case of multiple MCP servers in a single module, the discovery should discover the same tools for all MCP servers.
+ * The structure of test modules is the following:
+ *
+ *      TestModule
+ *          |
+ *          |
+ *       AppModule (server-a, server-b)
+ *          |
+ *          |
+ *        Tools
+ */
+describe('McpRegistryService - Single discovery root with multiple MCP servers', () => {
+  const mcpModuleA = McpModule.forRoot({ name: 'server-a', version: '0.0.1' });
+  const mcpModuleB = McpModule.forRoot({ name: 'server-b', version: '0.0.1' });
+
+  const idModuleA = getMcpModuleId(mcpModuleA);
+  const idModuleB = getMcpModuleId(mcpModuleB);
+
+  @Injectable()
+  class Tools {
+    @Tool({
+      name: 'tool',
+      description: 'Tool from AppModule',
+    })
+    tool() {
+      return 'Tool result';
+    }
+  }
+
+  @Module({
+    imports: [mcpModuleA, mcpModuleB],
+    providers: [Tools],
+  })
+  class AppModule {}
+
+  let service: McpRegistryService;
+
+  beforeAll(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    service = module.get<McpRegistryService>(McpRegistryService);
+    service.onApplicationBootstrap();
+  });
+
+  it('server-a discovered the tool', () => {
+    const tools = service.getTools(idModuleA);
+
+    expect(tools.length).toBe(1);
+
+    const tool = tools.find((tool) => tool.metadata.name === 'tool');
+    expect(tool).toBeDefined();
+  });
+
+  it('server-b discovered the tool', () => {
+    const tools = service.getTools(idModuleB);
+
+    expect(tools.length).toBe(1);
+
+    const tool = tools.find((tool) => tool.metadata.name === 'tool');
+    expect(tool).toBeDefined();
+  });
+});
+
+/**
+ * Helper function to get the MCP module ID from a DynamicModule.
+ * Pulling the IDs from the compiled TestingModule doesn't work as expected.
+ * It returns the same ID for both modules, which is the ID of the module registered last.
+ */
+function getMcpModuleId(module: DynamicModule): string {
+  const valueProvider = module?.providers?.find(
+    (provider) =>
+      typeof provider === 'object' &&
+      (provider as ValueProvider).provide === 'MCP_MODULE_ID',
+  ) as ValueProvider<string> | undefined;
+
+  if (!valueProvider) {
+    throw new Error(
+      'MCP_MODULE_ID provider not found in module. This should not happen.',
+    );
+  }
+
+  return valueProvider.useValue;
+}

--- a/src/transport/sse.controller.factory.ts
+++ b/src/transport/sse.controller.factory.ts
@@ -51,6 +51,7 @@ export function createSseController(
 
     constructor(
       @Inject('MCP_OPTIONS') public readonly options: McpOptions,
+      @Inject('MCP_MODULE_ID') public readonly mcpModuleId: string,
       public readonly applicationConfig: ApplicationConfig,
       public readonly moduleRef: ModuleRef,
       public readonly toolRegistry: McpRegistryService,
@@ -83,6 +84,7 @@ export function createSseController(
 
       // Create a new MCP server instance with dynamic capabilities
       const capabilities = buildMcpCapabilities(
+        this.mcpModuleId,
         this.toolRegistry,
         this.options,
       );

--- a/src/transport/stdio.service.ts
+++ b/src/transport/stdio.service.ts
@@ -18,6 +18,7 @@ export class StdioService implements OnApplicationBootstrap {
 
   constructor(
     @Inject('MCP_OPTIONS') private readonly options: McpOptions,
+    @Inject('MCP_MODULE_ID') private readonly mcpModuleId: string,
     private readonly moduleRef: ModuleRef,
     private readonly toolRegistry: McpRegistryService,
   ) {}
@@ -29,7 +30,11 @@ export class StdioService implements OnApplicationBootstrap {
     this.logger.log('Bootstrapping MCP STDIO...');
 
     // Create a new MCP server instance with dynamic capabilities
-    const capabilities = buildMcpCapabilities(this.toolRegistry, this.options);
+    const capabilities = buildMcpCapabilities(
+      this.mcpModuleId,
+      this.toolRegistry,
+      this.options,
+    );
     this.logger.debug('Built MCP capabilities:', capabilities);
 
     // Create MCP server with dynamic capabilities

--- a/src/transport/streamable-http.controller.factory.ts
+++ b/src/transport/streamable-http.controller.factory.ts
@@ -44,6 +44,7 @@ export function createStreamableHttpController(
 
     constructor(
       @Inject('MCP_OPTIONS') public readonly options: McpOptions,
+      @Inject('MCP_MODULE_ID') public readonly mcpModuleId: string,
       public readonly moduleRef: ModuleRef,
       public readonly toolRegistry: McpRegistryService,
     ) {
@@ -67,6 +68,7 @@ export function createStreamableHttpController(
 
       // Create a new MCP server instance with dynamic capabilities
       const capabilities = buildMcpCapabilities(
+        this.mcpModuleId,
         this.toolRegistry,
         this.options,
       );
@@ -206,6 +208,7 @@ export function createStreamableHttpController(
 
         // Create a new MCP server for this session with dynamic capabilities
         const capabilities = buildMcpCapabilities(
+          this.mcpModuleId,
           this.toolRegistry,
           this.options,
         );

--- a/src/utils/capabilities-builder.ts
+++ b/src/utils/capabilities-builder.ts
@@ -7,6 +7,7 @@ import { McpOptions } from '../interfaces';
  * discovered tools, resources, and prompts
  */
 export function buildMcpCapabilities(
+  mcpModuleId: string,
   registry: McpRegistryService,
   options: McpOptions,
 ): ServerCapabilities {
@@ -16,13 +17,13 @@ export function buildMcpCapabilities(
   const capabilities: ServerCapabilities = { ...baseCapabilities };
 
   // Add tools capability if tools are discovered
-  if (registry.getTools().length > 0) {
+  if (registry.getTools(mcpModuleId).length > 0) {
     capabilities.tools = capabilities.tools || {
       listChanged: true,
     };
   }
 
-  if (registry.getResources().length > 0) {
+  if (registry.getResources(mcpModuleId).length > 0) {
     capabilities.resources = capabilities.resources || {
       listChanged: true,
     };
@@ -34,7 +35,7 @@ export function buildMcpCapabilities(
   }
 
   // Add prompts capability if prompts are discovered
-  if (registry.getPrompts().length > 0) {
+  if (registry.getPrompts(mcpModuleId).length > 0) {
     capabilities.prompts = capabilities.prompts || {
       listChanged: true,
     };


### PR DESCRIPTION
Following up on https://github.com/rekog-labs/MCP-Nest/issues/69

This PR allows for multiple servers to run within a single Nest app, each having its own separate set of tools.

This is a breaking change - previously all tools were discovered regardless of where the McpModule was imported.

----

The key idea is that each instance of the McpModule gets its unique ID. That ID is then used as key when storing the discovered resources. Many of the changes are just propagating that ID + prettier breaking lines 😀 

Discovery-wise, the key part is injecting ModulesContainer and walking the tree. It doesn't use any internal APIs AFAIK.
I hit a circular dependency (mcp.module.ts imports mcp-registry.service.ts and vice versa), which is why I went for `__isMcpModule` instead of `instanceof McpModule`.

And ofc, I added two more sets of tests for the now-expected behavior.

----

@rinormaloku happy to hear your thoughts!
