### PR TITLE
fix: set strict mode to true when resolving McpExecutorService for re…

### DIFF
--- a/src/transport/streamable-http.controller.factory.ts
+++ b/src/transport/streamable-http.controller.factory.ts
@@ -90,7 +90,7 @@ export function createStreamableHttpController(
       const executor = await this.moduleRef.resolve(
         McpExecutorService,
         contextId,
-        { strict: false },
+        { strict: true },
       );
 
       // Register request handlers after connection
@@ -275,7 +275,7 @@ export function createStreamableHttpController(
       const executor = await this.moduleRef.resolve(
         McpExecutorService,
         contextId,
-        { strict: false },
+        { strict: true },
       );
 
       // Register request handlers with the user context from this specific request

--- a/tests/mcp-multi-module.e2e.spec.ts
+++ b/tests/mcp-multi-module.e2e.spec.ts
@@ -1,0 +1,149 @@
+import { INestApplication, Injectable, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { Tool } from '../src';
+import { McpModule } from '../src/mcp.module';
+import { createStreamableClient } from './utils';
+
+@Injectable()
+class ToolsA {
+  @Tool({
+    name: 'toolA',
+    description: 'Tool A from ModuleA',
+  })
+  toolA() {
+    return 'Tool A result';
+  }
+}
+
+@Injectable()
+class ToolsB {
+  @Tool({
+    name: 'toolB',
+    description: 'Tool B from ModuleB',
+  })
+  toolB() {
+    return 'Tool B result';
+  }
+}
+
+const mcpModuleA = McpModule.forRoot({
+  name: 'server-a',
+  mcpEndpoint: '/servers/a/mcp',
+  sseEndpoint: '/servers/a/sse',
+  messagesEndpoint: '/servers/a/messages',
+  capabilities: { tools: {} },
+  version: '0.0.1',
+});
+const mcpModuleB = McpModule.forRoot({
+  name: 'server-b',
+  mcpEndpoint: '/servers/b/mcp',
+  sseEndpoint: '/servers/b/sse',
+  messagesEndpoint: '/servers/b/messages',
+  version: '0.0.1',
+});
+
+@Module({
+  imports: [mcpModuleA],
+  providers: [ToolsA],
+  exports: [ToolsA],
+})
+class ModuleA {}
+
+@Module({
+  imports: [mcpModuleB],
+  providers: [ToolsB],
+  exports: [ToolsB],
+})
+class ModuleB {}
+
+describe('E2E: Multiple MCP servers (Streamable HTTP)', () => {
+  let app: INestApplication;
+  let statelessApp: INestApplication;
+  let statefulServerPort: number;
+  let statelessServerPort: number;
+
+  // Set timeout for all tests in this describe block to 15000ms
+  jest.setTimeout(15000);
+
+  beforeAll(async () => {
+    // Create stateful server (original)
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [ModuleA, ModuleB],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.listen(0);
+
+    const server = app.getHttpServer();
+    if (!server.address()) {
+      throw new Error('Server address not found after listen');
+    }
+    statefulServerPort = (server.address() as import('net').AddressInfo).port;
+
+    // Create stateless server
+    const statelessModuleFixture: TestingModule =
+      await Test.createTestingModule({
+        imports: [ModuleA, ModuleB],
+      }).compile();
+
+    statelessApp = statelessModuleFixture.createNestApplication();
+    await statelessApp.listen(0);
+
+    const statelessServer = statelessApp.getHttpServer();
+    if (!statelessServer.address()) {
+      throw new Error('Stateless server address not found after listen');
+    }
+    statelessServerPort = (
+      statelessServer.address() as import('net').AddressInfo
+    ).port;
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await statelessApp.close();
+  });
+
+  const runClientTests = (stateless: boolean) => {
+    describe(`${stateless ? 'stateless' : 'stateful'} client`, () => {
+      let port: number;
+
+      beforeAll(async () => {
+        port = stateless ? statelessServerPort : statefulServerPort;
+      });
+
+      it('should list tools for server A', async () => {
+        const client = await createStreamableClient(port, {
+          endpoint: '/servers/a/mcp',
+        });
+        try {
+          const tools = await client.listTools();
+          console.log(tools);
+          expect(tools.tools.length).toBe(1);
+          expect(tools.tools.find((t) => t.name === 'toolA')).toBeDefined();
+        } finally {
+          await client.close();
+        }
+      });
+
+      it('should list tools for server B', async () => {
+        const client = await createStreamableClient(port, {
+          endpoint: '/servers/b/mcp',
+        });
+        try {
+          const tools = await client.listTools();
+          console.log(tools);
+          expect(tools.tools.length).toBe(1);
+          expect(tools.tools.find((t) => t.name === 'toolB')).toBeDefined();
+        } finally {
+          await client.close();
+        }
+      });
+    });
+  };
+
+  // Run tests using the [Stateful] Streamable HTTP MCP client
+  runClientTests(false);
+
+  // Run tests using the [Stateless] Streamable HTTP MCP client
+  runClientTests(true);
+});


### PR DESCRIPTION
Following up on #69 

### What was changed

- Changed the strict option from false to true when resolving McpExecutorService using this.moduleRef.resolve.
- This ensures that dependency resolution is performed strictly within the current request context.

### Reason for the change

- When implementing multiple MCP servers using the streamable HTTP transport, there was a bug where only the last created McpExecutorService was returned.
- Enabling strict mode fixes this issue by ensuring that each request gets its own properly scoped McpExecutorService instance, rather than sharing or reusing the last one.

### Impact
- If all dependencies are properly registered, there should be no impact on existing functionality.
- If any required providers are missing in the current context, errors will now be thrown, making issues easier to detect and fix early.