### PR TITLE
fix: resolve default outputSchema handling bug

### DIFF
--- a/src/decorators/tool.decorator.ts
+++ b/src/decorators/tool.decorator.ts
@@ -39,8 +39,6 @@ export const Tool = (options: ToolOptions) => {
   if (options.parameters === undefined) {
     options.parameters = z.object({});
   }
-  if (options.outputSchema === undefined) {
-    options.outputSchema = z.any();
-  }
+
   return SetMetadata(MCP_TOOL_METADATA_KEY, options);
 };

--- a/tests/mcp-tool.e2e.spec.ts
+++ b/tests/mcp-tool.e2e.spec.ts
@@ -314,6 +314,19 @@ describe('E2E: MCP ToolServer', () => {
         }
       });
 
+      it('should list tools without outputSchema', async () => {
+        const client = await clientCreator(port);
+        try {
+          const tools = await client.listTools();
+          console.log('tools:', JSON.stringify(tools, null, 2));
+          expect(tools.tools.length).toBeGreaterThan(0);
+          const schemaTool = tools.tools.find((t) => t.name === 'hello-world');
+          expect(schemaTool?.outputSchema).not.toBeDefined();
+        } finally {
+          await client.close();
+        }
+      });
+
       it('should list tools with annotations', async () => {
         const client = await clientCreator(port);
         try {


### PR DESCRIPTION
### What was changed
- Fix issue with default outputSchema type validation
- Update e2e tests to verify default outputSchema behavior

### Reason for the change 
- An error occurs in the MCP Client when calling a tool that has a default outputSchema set.
- Test Tool Annotation
```
@Tool({
    name: 'hello-world',
    description:
      'Returns a greeting and simulates a long operation with progress updates',
    parameters: z.object({
      name: z.string().default('World'),
    }),
    annotations: {
      title: 'Greeting Tool',
      destructiveHint: false,
      readOnlyHint: true,
      idempotentHint: true,
      openWorldHint: false,
    },
  })
```

#### Screenshots
- MCP Inspector : 

![image](https://github.com/user-attachments/assets/9992a2e3-a94f-4fe5-8f74-3260a04275cf)

- Cursor

<img width="739" alt="스크린샷 2025-06-16 오전 11 26 13" src="https://github.com/user-attachments/assets/7c0d5b4e-5822-4028-8b72-50d78dee56f5" />


@luannhq could you please review this commit? 

