### PR TITLE
Fix mcp server resolution for SSE

### DIFF
--- a/src/transport/sse.controller.factory.ts
+++ b/src/transport/sse.controller.factory.ts
@@ -144,7 +144,6 @@ export function createSseController(
       const executor = await this.moduleRef.resolve(
         McpExecutorService,
         contextId,
-        { strict: false },
       );
 
       // Register request handlers with the user context from this specific request


### PR DESCRIPTION
`{ strict: false }` allows for cross-module resolution. So when I was using the changes from #73 I ran into an issue where regardless of which `/{module}/sse` endpoint I provided it was always resolving the last one. I tested this one using the MCP inspector and saw correctly that if I change the endpoint it return the proper list of tools and is able to call the tool as expected.

I was stoked to see that PR get merged and released since I already feel like I have a use case for it. Thanks!