### PR TITLE
Develop/wrap tool return data

### DIFF
--- a/src/services/handlers/mcp-tools.handler.ts
+++ b/src/services/handlers/mcp-tools.handler.ts
@@ -145,6 +145,7 @@ export class McpToolsHandler extends McpHandlerBase {
 
           const transformedResult = this.formatToolResult(result, toolInfo.metadata.outputSchema);
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           this.logger.debug(transformedResult, 'CallToolRequestSchema result');
 
           return transformedResult;

--- a/src/services/handlers/mcp-tools.handler.ts
+++ b/src/services/handlers/mcp-tools.handler.ts
@@ -38,7 +38,6 @@ export class McpToolsHandler extends McpHandlerBase {
     }
 
     if (outputSchema) {
-      // Validate result against outputSchema
       const validation = outputSchema.safeParse(result);
       if (!validation.success) {
         return {
@@ -49,7 +48,6 @@ export class McpToolsHandler extends McpHandlerBase {
           isError: true,
         };
       }
-      // If valid, proceed as before
       return {
         structuredContent: result,
         content: this.buildDefaultContentBlock(result),
@@ -147,7 +145,7 @@ export class McpToolsHandler extends McpHandlerBase {
 
           const transformedResult = this.formatToolResult(result, toolInfo.metadata.outputSchema);
 
-          this.logger.debug(transformedResult, 'CallToolRequestSchema result_____');
+          this.logger.debug(transformedResult, 'CallToolRequestSchema result');
 
           return transformedResult;
         } catch (error) {

--- a/src/services/handlers/mcp-tools.handler.ts
+++ b/src/services/handlers/mcp-tools.handler.ts
@@ -11,7 +11,7 @@ import { Request } from 'express';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { McpRegistryService } from '../mcp-registry.service';
 import { McpHandlerBase } from './mcp-handler.base';
-import { ZodTypeAny } from 'zod'; // Import Zod types if not already
+import { ZodTypeAny } from 'zod';
 
 @Injectable({ scope: Scope.REQUEST })
 export class McpToolsHandler extends McpHandlerBase {

--- a/tests/mcp-tool.e2e.spec.ts
+++ b/tests/mcp-tool.e2e.spec.ts
@@ -339,10 +339,6 @@ describe('E2E: MCP ToolServer', () => {
           const tools = await client.listTools();
           console.log('tools:', JSON.stringify(tools, null, 2));
           expect(tools.tools.length).toBeGreaterThan(0);
-
-          console.log(JSON.stringify(tools, null, 2));
-
-
           const outputSchemaTool = tools.tools.find(
             (t) => t.name === 'output-schema-tool',
           );
@@ -488,41 +484,41 @@ describe('E2E: MCP ToolServer', () => {
         }
       });
 
-      // it('should transform non-MCP-compliant response into MCP-compliant payload', async () => {
-      //   const client = await clientCreator(port);
-      //   try {
-      //     const result: any = await client.callTool({
-      //       name: 'not-mcp-greeting',
-      //       arguments: { name: 'TestUser' },
-      //     });
-      //     expect(result).toHaveProperty('content');
-      //     expect(Array.isArray(result.content)).toBe(true);
-      //     expect(result.content[0].type).toBe('text');
-      //     expect(result.content[0].text).toContain('greeting');
-      //     expect(result.content[0].text).toContain('Hello, TestUser!');
-      //   } finally {
-      //     await client.close();
-      //   }
-      // });
+      it('should transform non-MCP-compliant response into MCP-compliant payload', async () => {
+        const client = await clientCreator(port);
+        try {
+          const result: any = await client.callTool({
+            name: 'not-mcp-greeting',
+            arguments: { name: 'TestUser' },
+          });
+          expect(result).toHaveProperty('content');
+          expect(Array.isArray(result.content)).toBe(true);
+          expect(result.content[0].type).toBe('text');
+          expect(result.content[0].text).toContain('greeting');
+          expect(result.content[0].text).toContain('Hello, TestUser!');
+        } finally {
+          await client.close();
+        }
+      });
 
-      // it('should transform non-MCP-compliant response with outputSchema into MCP-compliant payload with structuredContent', async () => {
-      //   const client = await clientCreator(port);
-      //   try {
-      //     const result: any = await client.callTool({
-      //       name: 'not-mcp-structured-greeting',
-      //       arguments: { name: 'TestUser' },
-      //     });
-      //     expect(result).toHaveProperty('structuredContent');
-      //     expect(result.structuredContent).toEqual({ greeting: 'Hello, TestUser!' });
-      //     expect(result).toHaveProperty('content');
-      //     expect(Array.isArray(result.content)).toBe(true);
-      //     expect(result.content[0].type).toBe('text');
-      //     expect(result.content[0].text).toContain('greeting');
-      //     expect(result.content[0].text).toContain('Hello, TestUser!');
-      //   } finally {
-      //     await client.close();
-      //   }
-      // });
+      it('should transform non-MCP-compliant response with outputSchema into MCP-compliant payload with structuredContent', async () => {
+        const client = await clientCreator(port);
+        try {
+          const result: any = await client.callTool({
+            name: 'not-mcp-structured-greeting',
+            arguments: { name: 'TestUser' },
+          });
+          expect(result).toHaveProperty('structuredContent');
+          expect(result.structuredContent).toEqual({ greeting: 'Hello, TestUser!' });
+          expect(result).toHaveProperty('content');
+          expect(Array.isArray(result.content)).toBe(true);
+          expect(result.content[0].type).toBe('text');
+          expect(result.content[0].text).toContain('greeting');
+          expect(result.content[0].text).toContain('Hello, TestUser!');
+        } finally {
+          await client.close();
+        }
+      });
     });
   };
 

--- a/tests/mcp-tool.e2e.spec.ts
+++ b/tests/mcp-tool.e2e.spec.ts
@@ -180,6 +180,31 @@ class OutputSchemaTool {
   }
 }
 
+@Injectable()
+class NotMcpCompliantGreetingTool {
+  @Tool({
+    name: 'not-mcp-greeting',
+    description: 'Returns a plain object, not MCP-compliant',
+    parameters: z.object({ name: z.string().default('World') }),
+  })
+  async greet({ name }) {
+    return { greeting: `Hello, ${name}!` };
+  }
+}
+
+@Injectable()
+class NotMcpCompliantStructuredGreetingTool {
+  @Tool({
+    name: 'not-mcp-structured-greeting',
+    description: 'Returns a plain object with outputSchema',
+    parameters: z.object({ name: z.string().default('World') }),
+    outputSchema: z.object({ greeting: z.string() }),
+  })
+  async greet({ name }) {
+    return { greeting: `Hello, ${name}!` };
+  }
+}
+
 describe('E2E: MCP ToolServer', () => {
   let app: INestApplication;
   let statelessApp: INestApplication;
@@ -210,6 +235,8 @@ describe('E2E: MCP ToolServer', () => {
         MockUserRepository,
         ToolRequestScoped,
         OutputSchemaTool,
+        NotMcpCompliantGreetingTool,
+        NotMcpCompliantStructuredGreetingTool,
       ],
     }).compile();
 
@@ -244,6 +271,8 @@ describe('E2E: MCP ToolServer', () => {
           MockUserRepository,
           ToolRequestScoped,
           OutputSchemaTool,
+          NotMcpCompliantGreetingTool,
+          NotMcpCompliantStructuredGreetingTool,
         ],
       }).compile();
 
@@ -290,6 +319,15 @@ describe('E2E: MCP ToolServer', () => {
           expect(
             tools.tools.find((t) => t.name === 'get-request-scoped'),
           ).toBeDefined();
+          expect(
+            tools.tools.find((t) => t.name === 'output-schema-tool'),
+          ).toBeDefined();
+          expect(
+            tools.tools.find((t) => t.name === 'not-mcp-greeting'),
+          ).toBeDefined();
+          expect(
+            tools.tools.find((t) => t.name === 'not-mcp-structured-greeting'),
+          ).toBeDefined();
         } finally {
           await client.close();
         }
@@ -301,6 +339,10 @@ describe('E2E: MCP ToolServer', () => {
           const tools = await client.listTools();
           console.log('tools:', JSON.stringify(tools, null, 2));
           expect(tools.tools.length).toBeGreaterThan(0);
+
+          console.log(JSON.stringify(tools, null, 2));
+
+
           const outputSchemaTool = tools.tools.find(
             (t) => t.name === 'output-schema-tool',
           );
@@ -445,6 +487,42 @@ describe('E2E: MCP ToolServer', () => {
           await client.close();
         }
       });
+
+      // it('should transform non-MCP-compliant response into MCP-compliant payload', async () => {
+      //   const client = await clientCreator(port);
+      //   try {
+      //     const result: any = await client.callTool({
+      //       name: 'not-mcp-greeting',
+      //       arguments: { name: 'TestUser' },
+      //     });
+      //     expect(result).toHaveProperty('content');
+      //     expect(Array.isArray(result.content)).toBe(true);
+      //     expect(result.content[0].type).toBe('text');
+      //     expect(result.content[0].text).toContain('greeting');
+      //     expect(result.content[0].text).toContain('Hello, TestUser!');
+      //   } finally {
+      //     await client.close();
+      //   }
+      // });
+
+      // it('should transform non-MCP-compliant response with outputSchema into MCP-compliant payload with structuredContent', async () => {
+      //   const client = await clientCreator(port);
+      //   try {
+      //     const result: any = await client.callTool({
+      //       name: 'not-mcp-structured-greeting',
+      //       arguments: { name: 'TestUser' },
+      //     });
+      //     expect(result).toHaveProperty('structuredContent');
+      //     expect(result.structuredContent).toEqual({ greeting: 'Hello, TestUser!' });
+      //     expect(result).toHaveProperty('content');
+      //     expect(Array.isArray(result.content)).toBe(true);
+      //     expect(result.content[0].type).toBe('text');
+      //     expect(result.content[0].text).toContain('greeting');
+      //     expect(result.content[0].text).toContain('Hello, TestUser!');
+      //   } finally {
+      //     await client.close();
+      //   }
+      // });
     });
   };
 

--- a/tests/sample/stdio-server.ts
+++ b/tests/sample/stdio-server.ts
@@ -167,6 +167,32 @@ class OutputSchemaTool {
   }
 }
 
+@Injectable()
+class NotMcpCompliantGreetingTool {
+  @Tool({
+    name: 'not-mcp-greeting',
+    description: 'Returns a plain object, not MCP-compliant',
+    parameters: z.object({ name: z.string().default('World') }),
+  })
+  async greet({ name }) {
+    return { greeting: `Hello, ${name}!` };
+  }
+}
+
+@Injectable()
+class NotMcpCompliantStructuredGreetingTool {
+  @Tool({
+    name: 'not-mcp-structured-greeting',
+    description: 'Returns a plain object with outputSchema',
+    parameters: z.object({ name: z.string().default('World') }),
+    outputSchema: z.object({ greeting: z.string() }),
+  })
+  async greet({ name }) {
+    return { greeting: `Hello, ${name}!` };
+  }
+}
+
+
 @Module({
   imports: [
     McpModule.forRoot({
@@ -182,6 +208,8 @@ class OutputSchemaTool {
     MockUserRepository,
     ToolRequestScoped,
     OutputSchemaTool,
+    NotMcpCompliantGreetingTool,
+    NotMcpCompliantStructuredGreetingTool,
   ],
 })
 class StdioTestAppModule {}


### PR DESCRIPTION
Resolves #87 : ability to automatically wrap standard JSON structures in MCP complianet output as a single contentblock of type text with optional structuredContent support if outputSchema provided