### PR TITLE
Update zod dependency version in package.json to use caret notation

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@nestjs/core": ">=9.0.0",
     "express": ">=4.0.0",
     "reflect-metadata": ">=0.1.14",
-    "zod": ">=3.0.0",
+    "zod": "^3.0.0",
     "zod-to-json-schema": ">=3.23.0"
   },
   "devDependencies": {


### PR DESCRIPTION
[Zod v4](https://zod.dev/v4) released [a couple of days ago](https://www.npmjs.com/package/zod/v/4.0.0) and, because the version is specifed as `>=3.0.0`, v4 is picked during installation even though it's not compatible.

```bash
$ git clone https://github.com/rekog-labs/MCP-Nest.git && cd MCP-Nest
$ pnpm install

> @rekog/mcp-nest@1.6.2 prepare /Users/alxwrd/repos/MCP-Nest
> npm run build


> @rekog/mcp-nest@1.6.2 build
> tsc -p tsconfig.build.json --sourceMap --inlineSources

src/decorators/prompt.decorator.ts:3:19 - error TS2724: '"zod"' has no exported member named 'ZodTypeDef'. Did you mean 'ZodType'?

3 import { ZodType, ZodTypeDef, ZodOptional, ZodObject } from 'zod';
                    ~~~~~~~~~~

  node_modules/.pnpm/zod@4.0.5/node_modules/zod/v4/classic/schemas.d.cts:75:22
    75 export declare const ZodType: core.$constructor<ZodType>;
                            ~~~~~~~
    'ZodType' is declared here.
    
[...]

$ pnpm list
Legend: production dependency, optional only, dev only

@rekog/mcp-nest@1.6.2 ~/repos/MCP-Nest

dependencies:
path-to-regexp 8.2.0
reflect-metadata 0.2.2
zod 4.0.5
zod-to-json-schema 3.24.6
```
