### PR TITLE
feat(fastify): add fastify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export class AppModule {}
 // greeting.tool.ts
 import type { Request } from 'express';
 import { Injectable } from '@nestjs/common';
-import { Tool, Resource, Context } from '@rekog/mcp-nest';
+import { Tool, Resource, ResourceTemplate, Context } from '@rekog/mcp-nest';
 import { z } from 'zod';
 import { Progress } from '@modelcontextprotocol/sdk/types';
 
@@ -97,13 +97,32 @@ export class GreetingTool {
   }
 
   @Resource({
-    uri: 'mcp://hello-world/{userName}',
+    uri: 'mcp://hello-world',
     name: 'Hello World',
     description: 'A simple greeting resource',
     mimeType: 'text/plain',
   })
   // Different from the SDK, we put the parameters and URI in the same object.
-  async getCurrentSchema({ uri, userName }) {
+  async getHelloWorld({ uri }) {
+    return {
+      content: [
+        {
+          uri,
+          text: `Hello world`,
+          mimeType: 'text/plain',
+        },
+      ],
+    };
+  }
+
+  @ResourceTemplate({
+    uriTemplate: 'mcp://hello-world/{userName}',
+    name: 'Hello World',
+    description: 'A simple greeting resource',
+    mimeType: 'text/plain',
+  })
+  // Different from the SDK, we put the parameters and URI in the same object.
+  async getHello({ uri, userName }) {
     return {
       content: [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
+        "@fastify/cors": "^11.0.1",
+        "@nestjs/platform-fastify": "^11.1.5",
         "path-to-regexp": "^8.2.0"
       },
       "devDependencies": {
@@ -852,6 +854,178 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@fastify/ajv-compiler": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.2.tgz",
+      "integrity": "sha512-Rkiu/8wIjpsf46Rr+Fitd3HRP+VsxUFDDeag0hs9L0ksfnwx2g7SPQQTFL0E8Qv+rfXzQOxBJnjUB9ITUDjfWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/@fastify/cors": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.0.1.tgz",
+      "integrity": "sha512-dmZaE7M1f4SM8ZZuk5RhSsDJ+ezTgI7v3HHRj8Ow9CneczsPLZV6+2j2uwdaSLn8zhTv6QV0F4ZRcqdalGx1pQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "fastify-plugin": "^5.0.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/@fastify/error": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
+      "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/@fastify/fast-json-stringify-compiler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
+      "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "fast-json-stringify": "^6.0.0"
+      }
+    },
+    "node_modules/@fastify/formbody": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@fastify/formbody/-/formbody-8.0.2.tgz",
+      "integrity": "sha512-84v5J2KrkXzjgBpYnaNRPqwgMsmY7ZDjuj0YVuMR3NXCJRCgKEZy/taSP1wUYGn0onfxJpLyRGDLa+NMaDJtnA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "fast-querystring": "^1.1.2",
+        "fastify-plugin": "^5.0.0"
+      }
+    },
+    "node_modules/@fastify/forwarded": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.0.tgz",
+      "integrity": "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA=="
+    },
+    "node_modules/@fastify/merge-json-schemas": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
+      "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@fastify/middie": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@fastify/middie/-/middie-9.0.3.tgz",
+      "integrity": "sha512-7OYovKXp9UKYeVMcjcFLMcSpoMkmcZmfnG+eAvtdiatN35W7c+r9y1dRfpA+pfFVNuHGGqI3W+vDTmjvcfLcMA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastify-plugin": "^5.0.0",
+        "path-to-regexp": "^8.1.0",
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/@fastify/proxy-addr": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.0.0.tgz",
+      "integrity": "sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==",
+      "dependencies": {
+        "@fastify/forwarded": "^3.0.0",
+        "ipaddr.js": "^2.1.0"
+      }
+    },
+    "node_modules/@fastify/proxy-addr/node_modules/ipaddr.js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1294,7 +1468,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1607,7 +1780,6 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.1.tgz",
       "integrity": "sha512-crzp+1qeZ5EGL0nFTPy9NrVMAaUWewV5AwtQyv6SQ9yQPXwRl9W9hm1pt0nAtUu5QbYMbSuo7lYcF81EjM+nCA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "file-type": "20.5.0",
@@ -1639,7 +1811,6 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.1.tgz",
       "integrity": "sha512-UFoUAgLKFT+RwHTANJdr0dF7p0qS9QjkaUPjg8aafnjM/qxxxrUVDB49nVvyMlk+Hr1+vvcNaOHbWWQBxoZcHA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1681,7 +1852,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.1.tgz",
       "integrity": "sha512-IUxk380qnUtz0PCRQ5i+o9UHlGMrFzGPIJxDwyt3JZZwx2AngOlcEcm5e+7YeJQEr2QYX2QyC4tUQg0zde+D7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cors": "2.8.5",
@@ -1703,7 +1874,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -1717,7 +1888,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
       "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -1738,7 +1909,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
       "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -1751,7 +1922,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
       "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -1761,7 +1932,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1779,7 +1950,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -1822,7 +1993,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
       "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -1840,7 +2011,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
       "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1850,7 +2021,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
       "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -1860,7 +2031,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
       "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1873,7 +2044,7 @@
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1883,7 +2054,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
       "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -1896,14 +2067,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@nestjs/platform-express/node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -1913,7 +2084,7 @@
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1929,7 +2100,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
       "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
@@ -1952,7 +2123,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
       "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -1968,7 +2139,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
       "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^1.0.5",
@@ -1977,6 +2148,39 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/@nestjs/platform-fastify": {
+      "version": "11.1.5",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-11.1.5.tgz",
+      "integrity": "sha512-ZPYtXeG0m81Vu1F7tY3ywevScHnuDAOE9qDYQrPfxFnJPAUoFJoeR4oo795L4WLVOuPrywxtL0tpJvAf216VNA==",
+      "dependencies": {
+        "@fastify/cors": "11.0.1",
+        "@fastify/formbody": "8.0.2",
+        "@fastify/middie": "9.0.3",
+        "fast-querystring": "1.1.2",
+        "fastify": "5.4.0",
+        "light-my-request": "6.6.0",
+        "path-to-regexp": "8.2.0",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@fastify/view": "^10.0.0 || ^11.0.0",
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "@fastify/view": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2062,7 +2266,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
       "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -2129,7 +2332,6 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
       "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2148,7 +2350,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2166,14 +2367,12 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
@@ -2788,6 +2987,11 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -2855,6 +3059,42 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2915,7 +3155,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/arg": {
@@ -2962,6 +3202,23 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/avvio": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.1.0.tgz",
+      "integrity": "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==",
+      "dependencies": {
+        "@fastify/error": "^4.0.0",
+        "fastq": "^1.17.1"
+      }
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -3237,14 +3494,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
       "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -3256,7 +3513,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3266,7 +3523,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
       "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3280,7 +3537,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
       "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3509,7 +3766,7 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
+      "devOptional": true,
       "engines": [
         "node >= 0.8"
       ],
@@ -3525,7 +3782,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
       "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -3548,7 +3804,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3565,7 +3821,7 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -3589,14 +3845,14 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -3706,10 +3962,18 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/destroy": {
@@ -3768,7 +4032,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3793,7 +4057,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/ejs": {
@@ -3843,7 +4107,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3863,7 +4127,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3873,7 +4137,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3883,7 +4147,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3922,7 +4186,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -4239,7 +4503,7 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4388,11 +4652,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -4439,6 +4707,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-json-stringify": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.0.1.tgz",
+      "integrity": "sha512-s7SJE83QKBZwg54dIbD5rCtzOBVD43V1ReWXXYqBgwCwHLYAAT0RQc/FmrQglXqWPpz6omtryJQOau5jI4Nrvg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/merge-json-schemas": "^0.2.0",
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "fast-uri": "^3.0.0",
+        "json-schema-ref-resolver": "^2.0.0",
+        "rfdc": "^1.2.0"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -4446,18 +4757,95 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
+    "node_modules/fastify": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.4.0.tgz",
+      "integrity": "sha512-I4dVlUe+WNQAhKSyv15w+dwUh2EPiEl4X2lGYMmNSgF83WzTMAPKGdWEv5tPsCQOb+SOZwz8Vlta2vF+OeDgRw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "@fastify/ajv-compiler": "^4.0.0",
+        "@fastify/error": "^4.0.0",
+        "@fastify/fast-json-stringify-compiler": "^5.0.0",
+        "@fastify/proxy-addr": "^5.0.0",
+        "abstract-logging": "^2.0.1",
+        "avvio": "^9.0.0",
+        "fast-json-stringify": "^6.0.0",
+        "find-my-way": "^9.0.0",
+        "light-my-request": "^6.0.0",
+        "pino": "^9.0.0",
+        "process-warning": "^5.0.0",
+        "rfdc": "^1.3.1",
+        "secure-json-parse": "^4.0.0",
+        "semver": "^7.6.0",
+        "toad-cache": "^3.7.0"
+      }
+    },
+    "node_modules/fastify-plugin": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.1.tgz",
+      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ=="
+    },
+    "node_modules/fastify/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4477,7 +4865,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -4497,7 +4884,6 @@
       "version": "20.5.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
       "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.2.6",
@@ -4577,6 +4963,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/find-my-way": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
+      "integrity": "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-querystring": "^1.0.0",
+        "safe-regex2": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -4650,7 +5049,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -4692,7 +5091,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4722,7 +5121,7 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
       "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -4757,7 +5156,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -4829,7 +5228,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4866,7 +5265,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4895,7 +5294,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4915,7 +5314,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
       "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "depd": "2.0.0",
@@ -4942,7 +5341,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -4955,7 +5354,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5055,14 +5453,14 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -5161,7 +5559,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-stream": {
@@ -5181,7 +5579,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -5304,7 +5702,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
       "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=6"
@@ -5973,6 +6370,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-ref-resolver": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-2.0.1.tgz",
+      "integrity": "sha512-HG0SIB9X4J8bwbxCbnd5FfPEbcXAJYTi1pBJeP/QPON+w8ovSME8iRG+ElHNxZNX2Qh6eYn1GdzJFS4cDFfx0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6044,6 +6459,49 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/light-my-request": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
+      "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "process-warning": "^4.0.0",
+        "set-cookie-parser": "^2.6.0"
+      }
+    },
+    "node_modules/light-my-request/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/light-my-request/node_modules/process-warning": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
+      "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -6055,7 +6513,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
       "integrity": "sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6158,7 +6615,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6168,7 +6625,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6242,7 +6699,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6252,7 +6709,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6288,7 +6745,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6298,7 +6755,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"
@@ -6319,7 +6776,7 @@
       "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.2.tgz",
       "integrity": "sha512-VzGiVigcG9zUAoCNU+xShztrlr1auZOlurXynNvO9GiWD1/mTBbUljOKY+qMeazBqXgRnjzeEgJI/wyjJUHg9A==",
       "deprecated": "Multer 1.x is impacted by a number of vulnerabilities, which have been patched in 2.x. You should upgrade to the latest 2.x version.",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "append-field": "^1.0.0",
@@ -6392,7 +6849,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6402,7 +6859,7 @@
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
       "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6411,11 +6868,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -6428,7 +6893,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -6559,7 +7024,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6615,7 +7080,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
       "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6644,6 +7108,40 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
+      "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
     },
     "node_modules/pirates": {
       "version": "4.0.6",
@@ -6750,8 +7248,23 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -6771,7 +7284,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -6845,11 +7358,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6859,7 +7377,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
       "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
@@ -6882,7 +7400,7 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -6898,7 +7416,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/readdirp": {
@@ -6914,6 +7432,14 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
     "node_modules/reflect-metadata": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
@@ -6927,6 +7453,14 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6985,16 +7519,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/ret": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
+      "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
@@ -7014,7 +7560,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
       "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -7031,7 +7577,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7049,7 +7595,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/run-parallel": {
@@ -7080,7 +7626,6 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -7091,7 +7636,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -7108,12 +7653,53 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-regex2": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
+      "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "dependencies": {
+        "ret": "~0.5.0"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/secure-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
+      "integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7183,11 +7769,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/shebang-command": {
@@ -7217,7 +7808,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7237,7 +7828,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7254,7 +7845,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7273,7 +7864,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -7313,6 +7904,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7332,6 +7931,14 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -7358,7 +7965,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -7368,7 +7975,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -7377,7 +7984,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -7387,7 +7994,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/string-length": {
@@ -7469,7 +8076,6 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
       "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -7614,6 +8220,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -7634,11 +8248,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -7648,7 +8270,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
       "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -7876,7 +8497,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -7919,7 +8539,7 @@
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -7933,7 +8553,7 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -7977,7 +8597,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
       "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@lukeed/csprng": "^1.0.0"
@@ -7990,7 +8609,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
       "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8010,7 +8628,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8061,7 +8679,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -8100,7 +8718,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8164,7 +8782,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -8185,7 +8803,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,6 @@
       "version": "1.6.3",
       "license": "MIT",
       "dependencies": {
-        "@fastify/cors": "^11.0.1",
-        "@nestjs/platform-fastify": "^11.1.5",
         "path-to-regexp": "^8.2.0"
       },
       "devDependencies": {
@@ -40,10 +38,16 @@
         "@modelcontextprotocol/sdk": ">=1.10.0",
         "@nestjs/common": ">=9.0.0",
         "@nestjs/core": ">=9.0.0",
+        "@nestjs/platform-fastify": "^11.1.5",
         "express": ">=4.0.0",
         "reflect-metadata": ">=0.1.14",
         "zod": "^3.0.0",
         "zod-to-json-schema": ">=3.23.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-fastify": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -868,6 +872,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ajv": "^8.12.0",
         "ajv-formats": "^3.0.1",
@@ -878,6 +884,8 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -892,7 +900,9 @@
     "node_modules/@fastify/ajv-compiler/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@fastify/cors": {
       "version": "11.0.1",
@@ -908,6 +918,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fastify-plugin": "^5.0.0",
         "toad-cache": "^3.7.0"
@@ -926,7 +938,9 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/@fastify/fast-json-stringify-compiler": {
       "version": "5.0.3",
@@ -942,6 +956,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-json-stringify": "^6.0.0"
       }
@@ -960,6 +976,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-querystring": "^1.1.2",
         "fastify-plugin": "^5.0.0"
@@ -968,7 +986,9 @@
     "node_modules/@fastify/forwarded": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.0.tgz",
-      "integrity": "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA=="
+      "integrity": "sha512-kJExsp4JCms7ipzg7SJ3y8DwmePaELHxKYtg+tZow+k0znUTf3cb+npgyqm8+ATZOdmfgfydIebPDWM172wfyA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@fastify/merge-json-schemas": {
       "version": "0.2.1",
@@ -984,6 +1004,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -1002,6 +1024,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@fastify/error": "^4.0.0",
         "fastify-plugin": "^5.0.0",
@@ -1013,6 +1037,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.0.0.tgz",
       "integrity": "sha512-37qVVA1qZ5sgH7KpHkkC4z9SK6StIsIcOmpjvMPXNb3vx2GQxhZocogVYbr2PbbeLCQxYIPDok307xEvRZOzGA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@fastify/forwarded": "^3.0.0",
         "ipaddr.js": "^2.1.0"
@@ -1022,6 +1048,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
       "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -1468,6 +1496,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1780,6 +1809,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.1.tgz",
       "integrity": "sha512-crzp+1qeZ5EGL0nFTPy9NrVMAaUWewV5AwtQyv6SQ9yQPXwRl9W9hm1pt0nAtUu5QbYMbSuo7lYcF81EjM+nCA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "file-type": "20.5.0",
@@ -1811,6 +1841,7 @@
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-11.1.1.tgz",
       "integrity": "sha512-UFoUAgLKFT+RwHTANJdr0dF7p0qS9QjkaUPjg8aafnjM/qxxxrUVDB49nVvyMlk+Hr1+vvcNaOHbWWQBxoZcHA==",
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2154,6 +2185,8 @@
       "version": "11.1.5",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-fastify/-/platform-fastify-11.1.5.tgz",
       "integrity": "sha512-ZPYtXeG0m81Vu1F7tY3ywevScHnuDAOE9qDYQrPfxFnJPAUoFJoeR4oo795L4WLVOuPrywxtL0tpJvAf216VNA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@fastify/cors": "11.0.1",
         "@fastify/formbody": "8.0.2",
@@ -2266,6 +2299,7 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@nuxt/opencollective/-/opencollective-0.4.1.tgz",
       "integrity": "sha512-GXD3wy50qYbxCJ652bDrDzgMr3NFEkIS374+IgFQKkCvk9yiYcLvX2XDYr7UyQxf4wK0e+yqDYRubZ0DtOxnmQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3"
@@ -2332,6 +2366,7 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
       "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -2350,6 +2385,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2367,12 +2403,14 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
@@ -2990,7 +3028,9 @@
     "node_modules/abstract-logging": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
-      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -3063,6 +3103,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -3079,6 +3121,8 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -3093,7 +3137,9 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -3207,6 +3253,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3215,6 +3263,8 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.1.0.tgz",
       "integrity": "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@fastify/error": "^4.0.0",
         "fastq": "^1.17.1"
@@ -3782,6 +3832,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
       "integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -3972,6 +4023,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4655,12 +4708,15 @@
     "node_modules/fast-decode-uri-component": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
-      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -4721,6 +4777,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@fastify/merge-json-schemas": "^0.2.0",
         "ajv": "^8.12.0",
@@ -4734,6 +4792,8 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4748,7 +4808,9 @@
     "node_modules/fast-json-stringify/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -4761,6 +4823,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
       }
@@ -4769,6 +4833,8 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
       "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4777,6 +4843,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -4792,7 +4859,9 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/fastify": {
       "version": "5.4.0",
@@ -4808,6 +4877,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@fastify/ajv-compiler": "^4.0.0",
         "@fastify/error": "^4.0.0",
@@ -4829,12 +4900,16 @@
     "node_modules/fastify-plugin": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.0.1.tgz",
-      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ=="
+      "integrity": "sha512-HCxs+YnRaWzCl+cWRYFnHmeRFyR5GVnJTAaCJQiYzQSDwK9MgJdyAsuL3nh0EWRCYMgQ5MeziymvmAhUHYHDUQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/fastify/node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
       "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4846,6 +4921,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4865,6 +4941,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
       "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/file-entry-cache": {
@@ -4884,6 +4961,7 @@
       "version": "20.5.0",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
       "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/inflate": "^0.2.6",
@@ -4967,6 +5045,8 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
       "integrity": "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-querystring": "^1.0.0",
@@ -5354,6 +5434,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -5702,6 +5783,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/iterare/-/iterare-1.2.1.tgz",
       "integrity": "sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==",
+      "devOptional": true,
       "license": "ISC",
       "engines": {
         "node": ">=6"
@@ -6384,6 +6466,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -6473,6 +6557,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "process-warning": "^4.0.0",
@@ -6483,6 +6569,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6500,7 +6588,9 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -6513,6 +6603,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/load-esm/-/load-esm-1.0.2.tgz",
       "integrity": "sha512-nVAvWk/jeyrWyXEAs84mpQCYccxRqgKY4OznLuJhJCa0XsPSfdOIr2zvBZEj3IHEHbX97jjscKRRV539bW0Gpw==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -6872,6 +6963,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -7080,6 +7173,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
       "integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7113,6 +7207,8 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.7.0.tgz",
       "integrity": "sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0",
         "fast-redact": "^3.1.1",
@@ -7134,6 +7230,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
       "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "split2": "^4.0.0"
       }
@@ -7141,7 +7239,9 @@
     "node_modules/pino-std-serializers": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
-      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/pirates": {
       "version": "4.0.6",
@@ -7264,7 +7364,9 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -7361,7 +7463,9 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
-      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -7436,6 +7540,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -7461,6 +7567,8 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7523,6 +7631,8 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
       "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7531,6 +7641,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -7540,7 +7651,9 @@
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/rimraf": {
       "version": "2.7.1",
@@ -7626,6 +7739,7 @@
       "version": "7.8.1",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
       "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -7667,6 +7781,8 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ret": "~0.5.0"
       }
@@ -7675,6 +7791,8 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -7699,7 +7817,9 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "optional": true,
+      "peer": true
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7772,7 +7892,9 @@
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -7908,6 +8030,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
       "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
       }
@@ -7937,6 +8061,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -8076,6 +8202,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
       "integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -8224,6 +8351,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "real-require": "^0.2.0"
       }
@@ -8252,6 +8381,8 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
       "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8270,6 +8401,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
       "integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@tokenizer/token": "^0.3.0",
@@ -8497,6 +8629,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/type-check": {
@@ -8597,6 +8730,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
       "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@lukeed/csprng": "^1.0.0"
@@ -8609,6 +8743,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
       "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
     "build": "tsc -p tsconfig.build.json --sourceMap --inlineSources",
     "prepare": "npm run build",
     "start:playground": "ts-node-dev --respawn playground/servers/server-stateful.ts",
+    "start:fastify": "ts-node-dev --respawn playground/servers/server-fastify.ts",
     "test": "npx --node-options=--experimental-vm-modules jest",
     "test:watch": "npx --node-options=--experimental-vm-modules jest --watch",
+    "test:fastify": "ts-node playground/clients/http-fastify-client.ts",
     "lint": "eslint \"{src,apps,libs,tests}/**/*.ts\" --fix",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\""
   },
@@ -60,6 +62,8 @@
     "typescript-eslint": "^8.20.0"
   },
   "dependencies": {
+    "@fastify/cors": "^11.0.1",
+    "@nestjs/platform-fastify": "^11.1.5",
     "path-to-regexp": "^8.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,16 @@
     "@modelcontextprotocol/sdk": ">=1.10.0",
     "@nestjs/common": ">=9.0.0",
     "@nestjs/core": ">=9.0.0",
+    "@nestjs/platform-fastify": "^11.1.5",
     "express": ">=4.0.0",
     "reflect-metadata": ">=0.1.14",
     "zod": "^3.0.0",
     "zod-to-json-schema": ">=3.23.0"
+  },
+  "peerDependenciesMeta": {
+    "@nestjs/platform-fastify": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -62,8 +68,6 @@
     "typescript-eslint": "^8.20.0"
   },
   "dependencies": {
-    "@fastify/cors": "^11.0.1",
-    "@nestjs/platform-fastify": "^11.1.5",
     "path-to-regexp": "^8.2.0"
   }
 }

--- a/playground/clients/http-fastify-client.ts
+++ b/playground/clients/http-fastify-client.ts
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  CallToolRequest,
+  CallToolResultSchema,
+  ListToolsRequest,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+async function main(): Promise<void> {
+  // Test with Fastify server
+  const fastifyPort = 3031;
+  console.log(`🧪 Testing Fastify MCP server on port ${fastifyPort}`);
+
+  const client = new Client({
+    name: 'fastify-test-client',
+    version: '1.0.0',
+  });
+
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://localhost:${fastifyPort}/mcp`),
+  );
+
+  try {
+    // Connect the client using the transport and initialize the server
+    await client.connect(transport);
+    console.log('✅ Connected to Fastify MCP server');
+
+    // List available tools
+    await listTools(client);
+
+    // Call the greeting tool
+    await callGreetTool(client);
+
+    console.log('✅ Fastify server test completed successfully!');
+  } catch (error) {
+    console.error('❌ Error testing Fastify server:', error);
+    console.log('\nTrouble shooting:');
+    console.log('1. Make sure the Fastify server is running on port 3031');
+    console.log('2. Run: cd playground && npm run start:fastify');
+    console.log('3. Make sure @nestjs/platform-fastify is installed');
+  }
+
+  console.log('\nKeeping connection open for a few seconds...');
+  setTimeout(() => {
+    console.log('Disconnecting...');
+    process.exit(0);
+  }, 3000);
+}
+
+async function listTools(client: Client): Promise<void> {
+  try {
+    const toolsRequest: ListToolsRequest = {
+      method: 'tools/list',
+      params: {},
+    };
+    const toolsResult = await client.request(
+      toolsRequest,
+      ListToolsResultSchema,
+    );
+    console.log(
+      '📋 Available tools:',
+      toolsResult.tools.map((t) => t.name),
+    );
+    if (toolsResult.tools.length === 0) {
+      console.log('No tools available from the server');
+    }
+  } catch (error) {
+    console.log(`❌ Tools not supported by this server (${error})`);
+    return;
+  }
+}
+
+async function callGreetTool(client: Client): Promise<void> {
+  try {
+    const greetRequest: CallToolRequest = {
+      method: 'tools/call',
+      params: {
+        name: 'hello-world',
+        arguments: { name: 'Fastify User' },
+      },
+    };
+    const greetResult = await client.request(
+      greetRequest,
+      CallToolResultSchema,
+      {
+        onprogress: (progress) => {
+          console.log(`⏳ Progress: ${progress.progress}%`);
+        },
+      },
+    );
+    console.log('🎉 Greeting result:', greetResult.content[0].text);
+  } catch (error) {
+    console.log(`❌ Error calling greet tool: ${error}`);
+  }
+}
+
+main()
+  .then(() => {
+    console.log('Test completed.');
+  })
+  .catch((error: unknown) => {
+    console.error('Error running Fastify test client:', error);
+    process.exit(1);
+  });

--- a/playground/resources/greeting.resource.ts
+++ b/playground/resources/greeting.resource.ts
@@ -1,5 +1,5 @@
 import { Injectable, Scope } from '@nestjs/common';
-import { Resource } from '../../src';
+import { Resource, ResourceTemplate } from '../../src';
 
 @Injectable({ scope: Scope.REQUEST })
 export class GreetingResource {
@@ -7,15 +7,33 @@ export class GreetingResource {
 
   @Resource({
     name: 'hello-world',
-    description: 'A simple greeting resource',
+    description: 'A simple hello world resource',
     mimeType: 'text/plain',
-    uri: 'mcp://hello-world/{name}',
+    uri: 'mcp://hello-world',
   })
-  sayHello({ name }) {
+  sayHelloWorld({ uri }) {
     return {
       contents: [
         {
-          uri: 'mcp://hello-world',
+          uri: uri,
+          mimeType: 'text/plain',
+          text: `Hello world`,
+        },
+      ],
+    };
+  }
+
+  @ResourceTemplate({
+    name: 'hello-world',
+    description: 'A simple greeting resource',
+    mimeType: 'text/plain',
+    uriTemplate: 'mcp://hello-world/{name}',
+  })
+  sayHello({ uri, name }) {
+    return {
+      contents: [
+        {
+          uri: uri,
           mimeType: 'text/plain',
           text: `Hello ${name}`,
         },

--- a/playground/servers/server-fastify.ts
+++ b/playground/servers/server-fastify.ts
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import { NestFactory } from '@nestjs/core';
+import { z } from 'zod';
+import { Injectable, Module } from '@nestjs/common';
+import { Progress } from '@modelcontextprotocol/sdk/types.js';
+import { McpModule } from '../../src/mcp.module';
+import { Tool, Context, McpTransportType } from '../../src';
+
+@Injectable()
+class MockUserRepository {
+  async findByName(name: string) {
+    return Promise.resolve({
+      id: 'user123',
+      name: 'Repository User Name ' + name,
+      orgMemberships: [
+        {
+          orgId: 'org123',
+          organization: {
+            name: 'Repository Org',
+          },
+        },
+      ],
+    });
+  }
+}
+
+@Injectable()
+export class GreetingTool {
+  constructor(private readonly userRepository: MockUserRepository) {}
+
+  @Tool({
+    name: 'hello-world',
+    description: 'A sample tool that gets the user by name',
+    parameters: z.object({
+      name: z.string().default('World'),
+    }),
+  })
+  async sayHello({ name }: { name: string }, context: Context) {
+    const user = await this.userRepository.findByName(name);
+    for (let i = 0; i < 5; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await context.reportProgress({
+        progress: (i + 1) * 20,
+        total: 100,
+      } as Progress);
+    }
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Hello, ${user.name}! (via Fastify)`,
+        },
+      ],
+    };
+  }
+}
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'fastify-mcp-server',
+      version: '0.0.1',
+      transport: McpTransportType.STREAMABLE_HTTP,
+      streamableHttp: {
+        statelessMode: false,
+      },
+    }),
+  ],
+  providers: [GreetingTool, MockUserRepository],
+})
+export class AppModule {}
+
+async function bootstrap() {
+  let app;
+  let framework = 'Express (default)';
+
+  try {
+    // Try to use Fastify if available
+    const fastifyPlatform = await import('@nestjs/platform-fastify');
+    const adapter = new fastifyPlatform.FastifyAdapter();
+    app = await NestFactory.create(AppModule, adapter);
+    framework = 'Fastify';
+
+    // Enable CORS for testing with Fastify
+    try {
+      const fastifyCors = await import('@fastify/cors');
+      await app.register(fastifyCors.default, {
+        origin: true,
+        credentials: true,
+      });
+    } catch {
+      console.warn('CORS configuration skipped - @fastify/cors not available');
+    }
+  } catch (error) {
+    // Fallback to Express if Fastify is not available
+    console.warn(
+      'Fastify not available, falling back to Express. Install @nestjs/platform-fastify to use Fastify.',
+    );
+    app = await NestFactory.create(AppModule);
+    app.enableCors({
+      origin: true,
+      credentials: true,
+    });
+  }
+
+  const port = 3031;
+  console.log(`🚀 Starting MCP server on port ${port}`);
+  console.log(`📡 MCP endpoint available at: http://localhost:${port}/mcp`);
+  console.log(`🔧 Framework: ${framework}`);
+  console.log('');
+  console.log('To test with Fastify:');
+  console.log('1. Install: npm install @nestjs/platform-fastify @fastify/cors');
+  console.log('2. Restart the server');
+
+  await app.listen(port, '0.0.0.0');
+}
+
+bootstrap().catch((error) => {
+  console.error('Failed to start server:', error);
+  process.exit(1);
+});

--- a/playground/servers/server-fastify.ts
+++ b/playground/servers/server-fastify.ts
@@ -81,17 +81,6 @@ async function bootstrap() {
     const adapter = new fastifyPlatform.FastifyAdapter();
     app = await NestFactory.create(AppModule, adapter);
     framework = 'Fastify';
-
-    // Enable CORS for testing with Fastify
-    try {
-      const fastifyCors = await import('@fastify/cors');
-      await app.register(fastifyCors.default, {
-        origin: true,
-        credentials: true,
-      });
-    } catch {
-      console.warn('CORS configuration skipped - @fastify/cors not available');
-    }
   } catch (error) {
     // Fallback to Express if Fastify is not available
     console.warn(

--- a/src/adapters/express-http.adapter.ts
+++ b/src/adapters/express-http.adapter.ts
@@ -1,0 +1,57 @@
+import type { Request, Response } from 'express';
+import {
+  HttpAdapter,
+  HttpRequest,
+  HttpResponse,
+} from '../interfaces/http-adapter.interface';
+
+/**
+ * Express HTTP adapter that implements the generic HTTP interface
+ */
+export class ExpressHttpAdapter implements HttpAdapter {
+  adaptRequest(req: Request): HttpRequest {
+    return {
+      url: req.url,
+      method: req.method,
+      headers: req.headers as Record<string, string | string[] | undefined>,
+      query: req.query,
+      body: req.body,
+      params: req.params,
+      get: (name: string) => req.get(name),
+      raw: req,
+    };
+  }
+
+  adaptResponse(res: Response): HttpResponse {
+    return {
+      status: (code: number) => {
+        res.status(code);
+        return this.adaptResponse(res);
+      },
+      json: (body: any) => {
+        res.json(body);
+        return this.adaptResponse(res);
+      },
+      send: (body: string) => {
+        res.send(body);
+        return this.adaptResponse(res);
+      },
+      write: (chunk: any) => res.write(chunk),
+      setHeader: (name: string, value: string | string[]) =>
+        res.setHeader(name, value),
+      get headersSent() {
+        return res.headersSent;
+      },
+      get writable() {
+        return res.writable;
+      },
+      get closed() {
+        return res.destroyed || res.writableEnded;
+      },
+      on: (event: string, listener: (...args: any[]) => void) => {
+        res.on(event, listener);
+      },
+      raw: res,
+    };
+  }
+}

--- a/src/adapters/fastify-http.adapter.ts
+++ b/src/adapters/fastify-http.adapter.ts
@@ -1,0 +1,81 @@
+// Import types conditionally to avoid hard dependency
+interface FastifyRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string | string[]>;
+  query: Record<string, any>;
+  body: any;
+  params: Record<string, string>;
+  routeOptions?: any;
+}
+
+interface FastifyReply {
+  status(code: number): this;
+  send(payload: any): Promise<void>;
+  header(name: string, value: string | string[]): this;
+  sent: boolean;
+  raw: any;
+}
+
+import {
+  HttpAdapter,
+  HttpRequest,
+  HttpResponse,
+} from '../interfaces/http-adapter.interface';
+
+/**
+ * Fastify HTTP adapter that implements the generic HTTP interface
+ */
+export class FastifyHttpAdapter implements HttpAdapter {
+  adaptRequest(req: FastifyRequest): HttpRequest {
+    return {
+      url: req.url,
+      method: req.method,
+      headers: req.headers as Record<string, string | string[] | undefined>,
+      query: req.query,
+      body: req.body,
+      params: req.params,
+      get: (name: string) => {
+        const value = req.headers[name.toLowerCase()];
+        return Array.isArray(value) ? value[0] : value;
+      },
+      raw: (req as any).raw, // Raw Node.js IncomingMessage for MCP transport
+    };
+  }
+
+  adaptResponse(res: FastifyReply): HttpResponse {
+    return {
+      status: (code: number) => {
+        res.status(code);
+        return this.adaptResponse(res);
+      },
+      json: (body: any) => {
+        void res.send(body);
+        return this.adaptResponse(res);
+      },
+      send: (body: string) => {
+        void res.send(body);
+        return this.adaptResponse(res);
+      },
+      write: (chunk: any) => {
+        void res.raw.write(chunk);
+      },
+      setHeader: (name: string, value: string | string[]) => {
+        res.header(name, value);
+      },
+      get headersSent() {
+        return res.sent;
+      },
+      get writable() {
+        return !res.sent;
+      },
+      get closed() {
+        return res.sent;
+      },
+      on: (event: string, listener: (...args: any[]) => void) => {
+        res.raw.on(event, listener);
+      },
+      raw: res.raw, // Raw Node.js ServerResponse for MCP transport
+    };
+  }
+}

--- a/src/adapters/http-adapter.factory.ts
+++ b/src/adapters/http-adapter.factory.ts
@@ -1,0 +1,94 @@
+import { HttpAdapter } from '../interfaces/http-adapter.interface';
+import { ExpressHttpAdapter } from './express-http.adapter';
+import { FastifyHttpAdapter } from './fastify-http.adapter';
+
+/**
+ * Factory for creating HTTP adapters based on the detected framework
+ */
+export class HttpAdapterFactory {
+  private static expressAdapter: ExpressHttpAdapter | null = null;
+  private static fastifyAdapter: FastifyHttpAdapter | null = null;
+
+  /**
+   * Get the appropriate HTTP adapter for the given request/response objects
+   */
+  static getAdapter(req: any, res: any): HttpAdapter {
+    // Check if it's Express by looking for Express-specific properties
+    if (this.isExpressRequest(req) && this.isExpressResponse(res)) {
+      if (!this.expressAdapter) {
+        this.expressAdapter = new ExpressHttpAdapter();
+      }
+      return this.expressAdapter;
+    }
+
+    // Check if it's Fastify by looking for Fastify-specific properties
+    if (this.isFastifyRequest(req) && this.isFastifyReply(res)) {
+      if (!this.fastifyAdapter) {
+        this.fastifyAdapter = new FastifyHttpAdapter();
+      }
+      return this.fastifyAdapter;
+    }
+
+    // Default to Express adapter for backward compatibility
+    if (!this.expressAdapter) {
+      this.expressAdapter = new ExpressHttpAdapter();
+    }
+    return this.expressAdapter;
+  }
+
+  /**
+   * Check if the request object is from Express
+   */
+  private static isExpressRequest(req: any): boolean {
+    return Boolean(
+      req &&
+        typeof req === 'object' &&
+        typeof req.get === 'function' &&
+        req.method !== undefined &&
+        req.url !== undefined &&
+        !req.routeOptions, // Fastify-specific property
+    );
+  }
+
+  /**
+   * Check if the response object is from Express
+   */
+  private static isExpressResponse(res: any): boolean {
+    return Boolean(
+      res &&
+        typeof res === 'object' &&
+        typeof res.status === 'function' &&
+        typeof res.json === 'function' &&
+        typeof res.send === 'function' &&
+        res.headersSent !== undefined &&
+        !res.sent, // Fastify-specific property
+    );
+  }
+
+  /**
+   * Check if the request object is from Fastify
+   */
+  private static isFastifyRequest(req: any): boolean {
+    return Boolean(
+      req &&
+        typeof req === 'object' &&
+        req.routeOptions !== undefined && // Fastify-specific property
+        req.method !== undefined &&
+        req.url !== undefined,
+    );
+  }
+
+  /**
+   * Check if the response object is from Fastify (FastifyReply)
+   */
+  private static isFastifyReply(res: any): boolean {
+    return Boolean(
+      res &&
+        typeof res === 'object' &&
+        typeof res.status === 'function' &&
+        typeof res.send === 'function' &&
+        typeof res.header === 'function' &&
+        res.sent !== undefined, // Fastify-specific property
+    );
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,3 @@
+export * from './express-http.adapter';
+export * from './fastify-http.adapter';
+export * from './http-adapter.factory';

--- a/src/decorators/constants.ts
+++ b/src/decorators/constants.ts
@@ -1,3 +1,4 @@
 export const MCP_TOOL_METADATA_KEY = 'mcp:tool';
 export const MCP_RESOURCE_METADATA_KEY = 'mcp:resource';
+export const MCP_RESOURCE_TEMPLATE_METADATA_KEY = 'mcp:resource-template';
 export const MCP_PROMPT_METADATA_KEY = 'mcp:prompt';

--- a/src/decorators/index.ts
+++ b/src/decorators/index.ts
@@ -1,4 +1,5 @@
 export * from './tool.decorator';
 export * from './constants';
 export * from './resource.decorator';
+export * from './resource-template.decorator';
 export * from './prompt.decorator';

--- a/src/decorators/resource-template.decorator.ts
+++ b/src/decorators/resource-template.decorator.ts
@@ -1,0 +1,29 @@
+import { SetMetadata } from '@nestjs/common';
+import { MCP_RESOURCE_TEMPLATE_METADATA_KEY } from './constants';
+
+export type ResourceTemplateOptions =
+  // https://modelcontextprotocol.io/docs/concepts/resources#resource-templates
+  {
+    uriTemplate: string; // URI template following RFC 6570
+    name?: string; // Human-readable name
+    description?: string; // Optional description
+    mimeType?: string; // Optional MIME type
+  };
+
+export interface ResourceTemplateMetadata {
+  uriTemplate: string; // URI template following RFC 6570
+  name: string; // Human-readable name
+  description?: string; // Optional description
+  mimeType?: string; // Optional MIME type
+}
+
+/**
+ * Decorator that marks a controller method as an MCP resource.
+ * @param {Object} options - The options for the decorator
+ * @param {string} options.name - The name of the resource
+ * @param {string} options.uriTemplate - The URI template of the resource
+ * @returns {MethodDecorator} - The decorator
+ */
+export const ResourceTemplate = (options: ResourceTemplateOptions) => {
+  return SetMetadata(MCP_RESOURCE_TEMPLATE_METADATA_KEY, options);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './interfaces';
 export * from './mcp.module';
 export * from './services/mcp-registry.service';
 export * from './services/mcp-executor.service';
+export * from './adapters';

--- a/src/interfaces/http-adapter.interface.ts
+++ b/src/interfaces/http-adapter.interface.ts
@@ -1,0 +1,89 @@
+/**
+ * Generic HTTP request interface that abstracts Express and Fastify request objects
+ */
+export interface HttpRequest {
+  url?: string;
+  method?: string;
+  headers: Record<string, string | string[] | undefined>;
+  query: Record<string, any>;
+  body?: any;
+  params?: Record<string, string>;
+  /**
+   * Get a header value by name (case-insensitive)
+   */
+  get?(name: string): string | undefined;
+  /**
+   * Access to the raw framework-specific request object
+   */
+  raw?: any;
+}
+
+/**
+ * Generic HTTP response interface that abstracts Express and Fastify response objects
+ */
+export interface HttpResponse {
+  /**
+   * Set the response status code
+   */
+  status(code: number): this;
+
+  /**
+   * Send a JSON response
+   */
+  json(body: any): this | void;
+
+  /**
+   * Send a text response
+   */
+  send(body: string): this | void;
+
+  /**
+   * Write data to the response stream
+   */
+  write(chunk: any): boolean | void;
+
+  /**
+   * Set a response header
+   */
+  setHeader?(name: string, value: string | string[]): void;
+
+  /**
+   * Check if headers have been sent
+   */
+  readonly headersSent?: boolean;
+
+  /**
+   * Check if the response is writable
+   */
+  readonly writable?: boolean;
+
+  /**
+   * Check if the response is closed
+   */
+  readonly closed?: boolean;
+
+  /**
+   * Listen for events
+   */
+  on?(event: string, listener: (...args: any[]) => void): void;
+
+  /**
+   * Access to the raw framework-specific response object
+   */
+  raw?: any;
+}
+
+/**
+ * HTTP adapter interface for framework-specific implementations
+ */
+export interface HttpAdapter {
+  /**
+   * Adapt a framework-specific request to the generic HttpRequest interface
+   */
+  adaptRequest(req: any): HttpRequest;
+
+  /**
+   * Adapt a framework-specific response to the generic HttpResponse interface
+   */
+  adaptResponse(res: any): HttpResponse;
+}

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './mcp-options.interface';
 export * from './mcp-tool.interface';
+export * from './http-adapter.interface';

--- a/src/services/handlers/mcp-prompts.handler.ts
+++ b/src/services/handlers/mcp-prompts.handler.ts
@@ -8,9 +8,9 @@ import {
   McpError,
   PromptArgument,
 } from '@modelcontextprotocol/sdk/types.js';
-import { Request } from 'express';
 import { McpRegistryService } from '../mcp-registry.service';
 import { McpHandlerBase } from './mcp-handler.base';
+import { HttpRequest } from 'src/interfaces';
 
 @Injectable({ scope: Scope.REQUEST })
 export class McpPromptsHandler extends McpHandlerBase {
@@ -22,7 +22,7 @@ export class McpPromptsHandler extends McpHandlerBase {
     super(moduleRef, registry, McpPromptsHandler.name);
   }
 
-  registerHandlers(mcpServer: McpServer, httpRequest: Request) {
+  registerHandlers(mcpServer: McpServer, httpRequest: HttpRequest) {
     if (this.registry.getPrompts(this.mcpModuleId).length === 0) {
       this.logger.debug('No prompts registered, skipping prompt handlers');
       return;
@@ -90,7 +90,7 @@ export class McpPromptsHandler extends McpHandlerBase {
             promptInstance,
             request.params.arguments,
             context,
-            httpRequest,
+            httpRequest.raw,
           );
 
           this.logger.debug(result, 'GetPromptRequestSchema result');

--- a/src/services/handlers/mcp-resources.handler.ts
+++ b/src/services/handlers/mcp-resources.handler.ts
@@ -8,10 +8,9 @@ import {
   McpError,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import { Request } from 'express';
 import { McpRegistryService } from '../mcp-registry.service';
 import { McpHandlerBase } from './mcp-handler.base';
-import { Context } from 'src/interfaces';
+import { Context, HttpRequest } from 'src/interfaces';
 
 @Injectable({ scope: Scope.REQUEST })
 export class McpResourcesHandler extends McpHandlerBase {
@@ -23,7 +22,7 @@ export class McpResourcesHandler extends McpHandlerBase {
     super(moduleRef, registry, McpResourcesHandler.name);
   }
 
-  registerHandlers(mcpServer: McpServer, httpRequest: Request) {
+  registerHandlers(mcpServer: McpServer, httpRequest: HttpRequest) {
     const resources = this.registry.getResources(this.mcpModuleId);
     const resourceTemplates = this.registry.getResourceTemplates(
       this.mcpModuleId,
@@ -117,7 +116,7 @@ export class McpResourcesHandler extends McpHandlerBase {
   }
 
   private async handleRequest(
-    httpRequest: Request,
+    httpRequest: HttpRequest,
     providerClass: InjectionToken,
     uri: string,
     context: Context,
@@ -143,7 +142,7 @@ export class McpResourcesHandler extends McpHandlerBase {
       resourceInstance,
       requestParams,
       context,
-      httpRequest,
+      httpRequest.raw,
     );
 
     this.logger.debug(result, 'ReadResourceRequestSchema result');

--- a/src/services/handlers/mcp-resources.handler.ts
+++ b/src/services/handlers/mcp-resources.handler.ts
@@ -1,15 +1,17 @@
-import { Inject, Injectable, Scope } from '@nestjs/common';
+import { Inject, Injectable, InjectionToken, Scope } from '@nestjs/common';
 import { ContextIdFactory, ModuleRef } from '@nestjs/core';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import {
   ErrorCode,
   ListResourcesRequestSchema,
+  ListResourceTemplatesRequestSchema,
   McpError,
   ReadResourceRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import { Request } from 'express';
 import { McpRegistryService } from '../mcp-registry.service';
 import { McpHandlerBase } from './mcp-handler.base';
+import { Context } from 'src/interfaces';
 
 @Injectable({ scope: Scope.REQUEST })
 export class McpResourcesHandler extends McpHandlerBase {
@@ -22,8 +24,14 @@ export class McpResourcesHandler extends McpHandlerBase {
   }
 
   registerHandlers(mcpServer: McpServer, httpRequest: Request) {
-    if (this.registry.getResources(this.mcpModuleId).length === 0) {
-      this.logger.debug('No resources registered, skipping resource handlers');
+    const resources = this.registry.getResources(this.mcpModuleId);
+    const resourceTemplates = this.registry.getResourceTemplates(
+      this.mcpModuleId,
+    );
+    if (resources.length === 0 && resourceTemplates.length === 0) {
+      this.logger.debug(
+        'No resources or resource templates registered, skipping resource handlers',
+      );
       return;
     }
 
@@ -37,6 +45,18 @@ export class McpResourcesHandler extends McpHandlerBase {
     });
 
     mcpServer.server.setRequestHandler(
+      ListResourceTemplatesRequestSchema,
+      () => {
+        this.logger.debug('ListResourceTemplatesRequestSchema is being called');
+        return {
+          resourceTemplates: this.registry
+            .getResourceTemplates(this.mcpModuleId)
+            .map((resourceTemplate) => resourceTemplate.metadata),
+        };
+      },
+    );
+
+    mcpServer.server.setRequestHandler(
       ReadResourceRequestSchema,
       async (request) => {
         this.logger.debug('ReadResourceRequestSchema is being called');
@@ -46,51 +66,45 @@ export class McpResourcesHandler extends McpHandlerBase {
           this.mcpModuleId,
           uri,
         );
-
-        if (!resourceInfo) {
-          throw new McpError(
-            ErrorCode.MethodNotFound,
-            `Unknown resource: ${uri}`,
-          );
-        }
+        const resourceTemplateInfo = this.registry.findResourceTemplateByUri(
+          this.mcpModuleId,
+          uri,
+        );
 
         try {
-          const contextId = ContextIdFactory.getByRequest(httpRequest);
-          this.moduleRef.registerRequestByContextId(httpRequest, contextId);
+          let providerClass: InjectionToken;
+          let params: Record<string, unknown> = {};
+          let methodName: string;
+          if (resourceTemplateInfo) {
+            providerClass = resourceTemplateInfo.resourceTemplate.providerClass;
+            params = {
+              ...resourceTemplateInfo.params,
+              ...request.params,
+            };
+            methodName = resourceTemplateInfo.resourceTemplate.methodName;
+          } else if (resourceInfo) {
+            providerClass = resourceInfo.resource.providerClass;
 
-          const resourceInstance = await this.moduleRef.resolve(
-            resourceInfo.resource.providerClass,
-            contextId,
-            { strict: false },
-          );
-
-          if (!resourceInstance) {
+            params = {
+              ...resourceInfo.params,
+              ...request.params,
+            };
+            methodName = resourceInfo.resource.methodName;
+          } else {
             throw new McpError(
               ErrorCode.MethodNotFound,
               `Unknown resource: ${uri}`,
             );
           }
-
-          const context = this.createContext(mcpServer, request);
-
-          const requestParams = {
-            ...resourceInfo.params,
-            ...request.params,
-          };
-
-          const methodName = resourceInfo.resource.methodName;
-
-          const result = await resourceInstance[methodName].call(
-            resourceInstance,
-            requestParams,
-            context,
-            httpRequest,
-          );
-
-          this.logger.debug(result, 'ReadResourceRequestSchema result');
-
           // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-          return result;
+          return await this.handleRequest(
+            httpRequest,
+            providerClass,
+            uri,
+            this.createContext(mcpServer, request),
+            params,
+            methodName,
+          );
         } catch (error) {
           this.logger.error(error);
           return {
@@ -100,5 +114,41 @@ export class McpResourcesHandler extends McpHandlerBase {
         }
       },
     );
+  }
+
+  private async handleRequest(
+    httpRequest: Request,
+    providerClass: InjectionToken,
+    uri: string,
+    context: Context,
+    requestParams: Record<string, unknown>,
+    methodName: string,
+  ) {
+    const contextId = ContextIdFactory.getByRequest(httpRequest);
+    this.moduleRef.registerRequestByContextId(httpRequest, contextId);
+
+    const resourceInstance = await this.moduleRef.resolve(
+      providerClass,
+      contextId,
+      { strict: false },
+    );
+
+    if (!resourceInstance) {
+      throw new McpError(
+        ErrorCode.MethodNotFound,
+        `Unknown resource template: ${uri}`,
+      );
+    }
+    const result = await resourceInstance[methodName].call(
+      resourceInstance,
+      requestParams,
+      context,
+      httpRequest,
+    );
+
+    this.logger.debug(result, 'ReadResourceRequestSchema result');
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return result;
   }
 }

--- a/src/services/handlers/mcp-tools.handler.ts
+++ b/src/services/handlers/mcp-tools.handler.ts
@@ -42,7 +42,7 @@ export class McpToolsHandler extends McpHandlerBase {
       if (!validation.success) {
         throw new McpError(
           ErrorCode.InternalError,
-          `Tool result does not match outputSchema: ${validation.error.message}`
+          `Tool result does not match outputSchema: ${validation.error.message}`,
         );
       }
       return {
@@ -140,9 +140,11 @@ export class McpToolsHandler extends McpHandlerBase {
             httpRequest,
           );
 
-          const transformedResult = this.formatToolResult(result, toolInfo.metadata.outputSchema);
+          const transformedResult = this.formatToolResult(
+            result,
+            toolInfo.metadata.outputSchema,
+          );
 
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           this.logger.debug(transformedResult, 'CallToolRequestSchema result');
 
           return transformedResult;

--- a/src/services/handlers/mcp-tools.handler.ts
+++ b/src/services/handlers/mcp-tools.handler.ts
@@ -7,11 +7,11 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import { Inject, Injectable, Scope } from '@nestjs/common';
 import { ContextIdFactory, ModuleRef } from '@nestjs/core';
-import { Request } from 'express';
 import { zodToJsonSchema } from 'zod-to-json-schema';
 import { McpRegistryService } from '../mcp-registry.service';
 import { McpHandlerBase } from './mcp-handler.base';
 import { ZodTypeAny } from 'zod';
+import { HttpRequest } from 'src/interfaces';
 
 @Injectable({ scope: Scope.REQUEST })
 export class McpToolsHandler extends McpHandlerBase {
@@ -56,7 +56,7 @@ export class McpToolsHandler extends McpHandlerBase {
     };
   }
 
-  registerHandlers(mcpServer: McpServer, httpRequest: Request) {
+  registerHandlers(mcpServer: McpServer, httpRequest: HttpRequest) {
     if (this.registry.getTools(this.mcpModuleId).length === 0) {
       this.logger.debug('No tools registered, skipping tool handlers');
       return;
@@ -137,7 +137,7 @@ export class McpToolsHandler extends McpHandlerBase {
             toolInstance,
             request.params.arguments,
             context,
-            httpRequest,
+            httpRequest.raw,
           );
 
           const transformedResult = this.formatToolResult(
@@ -147,6 +147,7 @@ export class McpToolsHandler extends McpHandlerBase {
 
           this.logger.debug(transformedResult, 'CallToolRequestSchema result');
 
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
           return transformedResult;
         } catch (error) {
           this.logger.error(error);

--- a/src/services/mcp-executor.service.ts
+++ b/src/services/mcp-executor.service.ts
@@ -1,11 +1,11 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Inject, Injectable, Logger, Scope } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
-import { Request } from 'express';
 import { McpRegistryService } from './mcp-registry.service';
 import { McpToolsHandler } from './handlers/mcp-tools.handler';
 import { McpResourcesHandler } from './handlers/mcp-resources.handler';
 import { McpPromptsHandler } from './handlers/mcp-prompts.handler';
+import { HttpRequest } from 'src/interfaces';
 
 /**
  * Request-scoped service for executing MCP tools
@@ -40,7 +40,7 @@ export class McpExecutorService {
    * @param mcpServer - The MCP server instance
    * @param request - The current HTTP request object
    */
-  registerRequestHandlers(mcpServer: McpServer, httpRequest: Request) {
+  registerRequestHandlers(mcpServer: McpServer, httpRequest: HttpRequest) {
     this.toolsHandler.registerHandlers(mcpServer, httpRequest);
     this.resourcesHandler.registerHandlers(mcpServer, httpRequest);
     this.promptsHandler.registerHandlers(mcpServer, httpRequest);

--- a/src/services/mcp-registry.service.spec.ts
+++ b/src/services/mcp-registry.service.spec.ts
@@ -21,6 +21,13 @@ describe('McpRegistryService', () => {
     methodName: 'someMethod',
   });
 
+  const mockResourceTemplate = (name: string, uriTemplate: string) => ({
+    type: 'resource-template',
+    metadata: { name, uriTemplate },
+    providerClass: Symbol(name),
+    methodName: 'someMethod',
+  });
+
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -45,8 +52,13 @@ describe('McpRegistryService', () => {
       mockResource('res3', 'mcp://hello-world'),
     ];
 
+    const mockResourceTemplates = [
+      mockResourceTemplate('resTemplate1', '/templates/{id}'),
+      mockResourceTemplate('resTemplate2', '/templates/{type}/{id}'),
+    ];
+
     (service as any).discoveredToolsByMcpModuleId = new Map([
-      [mockMcpModuleId, mockResources],
+      [mockMcpModuleId, [...mockResources, ...mockResourceTemplates]],
     ]);
   });
 
@@ -92,6 +104,15 @@ describe('McpRegistryService', () => {
     );
     expect(result?.resource.metadata.name).toBe('res3');
     expect(result?.params).toEqual({});
+  });
+
+  it('should return the correct resource template by URI', () => {
+    const result = service.findResourceTemplateByUri(
+      mockMcpModuleId,
+      '/templates/123',
+    );
+    expect(result?.resourceTemplate.metadata.name).toBe('resTemplate1');
+    expect(result?.params).toEqual({ id: '123' });
   });
 });
 

--- a/src/services/mcp-registry.service.ts
+++ b/src/services/mcp-registry.service.ts
@@ -12,6 +12,7 @@ import {
 import {
   MCP_PROMPT_METADATA_KEY,
   MCP_RESOURCE_METADATA_KEY,
+  MCP_RESOURCE_TEMPLATE_METADATA_KEY,
   MCP_TOOL_METADATA_KEY,
   ToolMetadata,
 } from '../decorators';
@@ -19,12 +20,13 @@ import { ResourceMetadata } from '../decorators/resource.decorator';
 import { match } from 'path-to-regexp';
 import { PromptMetadata } from '../decorators/prompt.decorator';
 import { Module } from '@nestjs/core/injector/module';
+import { ResourceTemplateMetadata } from 'src/decorators/resource-template.decorator';
 
 /**
  * Interface representing a discovered tool
  */
 export type DiscoveredTool<T extends object> = {
-  type: 'tool' | 'resource' | 'prompt';
+  type: 'tool' | 'resource' | 'resource-template' | 'prompt';
   metadata: T;
   providerClass: InjectionToken;
   methodName: string;
@@ -67,7 +69,7 @@ export class McpRegistryService implements OnApplicationBootstrap {
 
     for (const [rootModule, mcpModules] of pairs) {
       this.logger.debug(
-        `Discovering tools, resources, and prompts for module: ${rootModule.name}`,
+        `Discovering tools, resources, resource templates, and prompts for module: ${rootModule.name}`,
       );
 
       const subtreeModules = this.collectSubtreeModules(rootModule);
@@ -118,8 +120,9 @@ export class McpRegistryService implements OnApplicationBootstrap {
     const discovered: {
       tools: string[];
       resources: string[];
+      resourceTemplates: string[];
       prompts: string[];
-    } = { tools: [], resources: [], prompts: [] };
+    } = { tools: [], resources: [], resourceTemplates: [], prompts: [] };
 
     allInstances.forEach(({ instance, token }) => {
       this.metadataScanner.getAllMethodNames(instance).forEach((methodName) => {
@@ -136,6 +139,18 @@ export class McpRegistryService implements OnApplicationBootstrap {
           discovered.resources.push(`${token.toString()}.${methodName}`);
         }
 
+        if (methodMetaKeys.includes(MCP_RESOURCE_TEMPLATE_METADATA_KEY)) {
+          this.addDiscoveryResourceTemplate(
+            mcpModuleId,
+            methodRef,
+            token,
+            methodName,
+          );
+          discovered.resourceTemplates.push(
+            `${token.toString()}.${methodName}`,
+          );
+        }
+
         if (methodMetaKeys.includes(MCP_PROMPT_METADATA_KEY)) {
           this.addDiscoveryPrompt(mcpModuleId, methodRef, token, methodName);
           discovered.prompts.push(`${token.toString()}.${methodName}`);
@@ -150,6 +165,13 @@ export class McpRegistryService implements OnApplicationBootstrap {
       `Discovered resources: ${discovered.resources.length ? discovered.resources.join(', ') : 'none'}`,
     );
     this.logger.debug(
+      `Discovered resource templates: ${
+        discovered.resourceTemplates.length
+          ? discovered.resourceTemplates.join(', ')
+          : 'none'
+      }`,
+    );
+    this.logger.debug(
       `Discovered prompts: ${discovered.prompts.length ? discovered.prompts.join(', ') : 'none'}`,
     );
   }
@@ -158,7 +180,7 @@ export class McpRegistryService implements OnApplicationBootstrap {
    * Adds a discovered tool to the registry
    */
   private addDiscovery<T>(
-    type: 'tool' | 'resource' | 'prompt',
+    type: 'tool' | 'resource' | 'resource-template' | 'prompt',
     metadataKey: string,
     mcpModuleId: string,
     methodRef: object,
@@ -231,6 +253,22 @@ export class McpRegistryService implements OnApplicationBootstrap {
     );
   }
 
+  private addDiscoveryResourceTemplate(
+    mcpModuleId: string,
+    methodRef: object,
+    token: InjectionToken,
+    methodName: string,
+  ) {
+    this.addDiscovery<ResourceTemplateMetadata>(
+      'resource-template',
+      MCP_RESOURCE_TEMPLATE_METADATA_KEY,
+      mcpModuleId,
+      methodRef,
+      token,
+      methodName,
+    );
+  }
+
   /**
    * Get all discovered tools
    */
@@ -273,6 +311,31 @@ export class McpRegistryService implements OnApplicationBootstrap {
     name: string,
   ): DiscoveredTool<ResourceMetadata> | undefined {
     return this.getResources(mcpModuleId).find(
+      (tool) => tool.metadata.name === name,
+    );
+  }
+
+  /**
+   * Get all discovered resource templates
+   */
+  getResourceTemplates(
+    mcpModuleId: string,
+  ): DiscoveredTool<ResourceTemplateMetadata>[] {
+    return (
+      this.discoveredToolsByMcpModuleId
+        .get(mcpModuleId)
+        ?.filter((tool) => tool.type === 'resource-template') ?? []
+    );
+  }
+
+  /**
+   * Find a resource by name
+   */
+  findResourceTemplate(
+    mcpModuleId: string,
+    name: string,
+  ): DiscoveredTool<ResourceTemplateMetadata> | undefined {
+    return this.getResourceTemplates(mcpModuleId).find(
       (tool) => tool.metadata.name === name,
     );
   }
@@ -346,6 +409,53 @@ export class McpRegistryService implements OnApplicationBootstrap {
 
         return {
           resource: foundResource,
+          params: result.params as Record<string, string>,
+        };
+      }
+    }
+
+    return undefined;
+  }
+
+  /**
+   * Find a resource template by uri
+   * @returns An object containing the found resource template and extracted parameters, or undefined if no resource template is found
+   */
+  findResourceTemplateByUri(
+    mcpModuleId: string,
+    uri: string,
+  ):
+    | {
+        resourceTemplate: DiscoveredTool<ResourceTemplateMetadata>;
+        params: Record<string, string>;
+      }
+    | undefined {
+    const resourceTemplates = this.getResourceTemplates(mcpModuleId).map(
+      (tool) => ({
+        name: tool.metadata.name,
+        uriTemplate: tool.metadata.uriTemplate,
+      }),
+    );
+
+    const strippedInputUri = this.convertUri(uri);
+
+    for (const t of resourceTemplates) {
+      if (!t.uriTemplate) continue;
+
+      const rawTemplate = t.uriTemplate;
+      const templatePath = this.convertTemplate(this.convertUri(rawTemplate));
+      const matcher = match(templatePath, { decode: decodeURIComponent });
+      const result = matcher(strippedInputUri);
+
+      if (result) {
+        const foundResourceTemplate = this.findResourceTemplate(
+          mcpModuleId,
+          t.name,
+        );
+        if (!foundResourceTemplate) continue;
+
+        return {
+          resourceTemplate: foundResourceTemplate,
           params: result.params as Record<string, string>,
         };
       }

--- a/src/services/sse-ping.service.ts
+++ b/src/services/sse-ping.service.ts
@@ -5,7 +5,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
-import type { Response } from 'express';
+import { HttpResponse } from 'src/interfaces';
 
 /**
  * Service that implements automatic ping for SSE connections
@@ -19,7 +19,7 @@ export class SsePingService implements OnModuleInit, OnModuleDestroy {
     string,
     {
       transport: SSEServerTransport;
-      res: Response;
+      res: HttpResponse;
     }
   >();
 
@@ -58,7 +58,7 @@ export class SsePingService implements OnModuleInit, OnModuleDestroy {
   registerConnection(
     sessionId: string,
     transport: SSEServerTransport,
-    res: Response,
+    res: HttpResponse,
   ) {
     this.activeConnections.set(sessionId, { transport, res });
     this.logger.debug(`SSE connection registered: ${sessionId}`);

--- a/src/transport/sse.controller.factory.ts
+++ b/src/transport/sse.controller.factory.ts
@@ -15,7 +15,6 @@ import {
   applyDecorators,
 } from '@nestjs/common';
 import { ApplicationConfig, ContextIdFactory, ModuleRef } from '@nestjs/core';
-import type { Request, Response } from 'express';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
@@ -25,6 +24,7 @@ import { McpExecutorService } from '../services/mcp-executor.service';
 import { McpRegistryService } from '../services/mcp-registry.service';
 import { SsePingService } from '../services/sse-ping.service';
 import { normalizeEndpoint } from '../utils/normalize-endpoint';
+import { HttpAdapterFactory } from '../adapters';
 
 /**
  * Creates a controller for handling SSE connections and tool executions
@@ -75,12 +75,16 @@ export function createSseController(
      */
     @Get(sseEndpoint)
     @UseGuards(...guards)
-    async sse(@Res() res: Response) {
+    async sse(@Req() rawReq: any, @Res() rawRes: any) {
+      const adapter = HttpAdapterFactory.getAdapter(rawReq, rawRes);
+      const res = adapter.adaptResponse(rawRes);
+      // Create a new SSE transport instance
+
       const transport = new SSEServerTransport(
         normalizeEndpoint(
           `${apiPrefix}/${this.applicationConfig.getGlobalPrefix()}/${messagesEndpoint}`,
         ),
-        res,
+        res.raw,
       );
       const sessionId = transport.sessionId;
 
@@ -124,10 +128,13 @@ export function createSseController(
     @Post(messagesEndpoint)
     @UseGuards(...guards)
     async messages(
-      @Req() req: Request,
-      @Res() res: Response,
+      @Req() rawReq: any,
+      @Res() rawRes: any,
       @Body() body: unknown,
     ) {
+      const adapter = HttpAdapterFactory.getAdapter(rawReq, rawRes);
+      const req = adapter.adaptRequest(rawReq);
+      const res = adapter.adaptResponse(rawRes);
       const sessionId = req.query.sessionId as string;
       const transport = this.transports.get(sessionId);
 
@@ -151,7 +158,7 @@ export function createSseController(
       executor.registerRequestHandlers(mcpServer, req);
 
       // Process the message
-      await transport.handlePostMessage(req, res, body);
+      await transport.handlePostMessage(req.raw, res.raw, body);
     }
   }
 

--- a/src/utils/capabilities-builder.ts
+++ b/src/utils/capabilities-builder.ts
@@ -27,8 +27,9 @@ export function buildMcpCapabilities(
     capabilities.resources = capabilities.resources || {
       listChanged: true,
     };
+  }
 
-    // ToDo: Move into its own condition when we split Resources and ResourceTemplates
+  if (registry.getResourceTemplates(mcpModuleId).length > 0) {
     capabilities.resourceTemplates = capabilities.resourceTemplates || {
       listChanged: true,
     };

--- a/src/utils/capabilities-builder.ts
+++ b/src/utils/capabilities-builder.ts
@@ -23,14 +23,11 @@ export function buildMcpCapabilities(
     };
   }
 
-  if (registry.getResources(mcpModuleId).length > 0) {
+  if (
+    registry.getResources(mcpModuleId).length > 0 ||
+    registry.getResourceTemplates(mcpModuleId).length > 0
+  ) {
     capabilities.resources = capabilities.resources || {
-      listChanged: true,
-    };
-  }
-
-  if (registry.getResourceTemplates(mcpModuleId).length > 0) {
-    capabilities.resourceTemplates = capabilities.resourceTemplates || {
       listChanged: true,
     };
   }

--- a/tests/mcp-fastify-adapter.e2e.spec.ts
+++ b/tests/mcp-fastify-adapter.e2e.spec.ts
@@ -1,0 +1,464 @@
+import { Progress } from '@modelcontextprotocol/sdk/types.js';
+import { INestApplication, Injectable, Scope } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { z } from 'zod';
+import { Context, McpTransportType, Tool } from '../src';
+import { McpModule } from '../src/mcp.module';
+import { createStreamableClient } from './utils';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { randomUUID } from 'crypto';
+import {
+  CallToolRequest,
+  CallToolResultSchema,
+  ListToolsRequest,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+@Injectable()
+class MockUserRepository {
+  async findByName(name: string) {
+    return Promise.resolve({
+      id: 'user123',
+      name: 'Fastify User ' + name,
+      framework: 'fastify',
+    });
+  }
+}
+
+@Injectable()
+export class FastifyTestTool {
+  constructor(private readonly userRepository: MockUserRepository) {}
+
+  @Tool({
+    name: 'fastify-hello-world',
+    description: 'A test tool to verify Fastify adapter works',
+    parameters: z.object({
+      name: z.string().default('World'),
+    }),
+  })
+  async sayHello({ name }: { name: string }, context: Context) {
+    // Validate that context properties exist
+    if (!context.mcpServer) {
+      throw new Error('mcpServer is not defined in the context');
+    }
+    if (!context.mcpRequest) {
+      throw new Error('mcpRequest is not defined in the context');
+    }
+
+    const user = await this.userRepository.findByName(name);
+    
+    // Report progress to test streaming works
+    for (let i = 0; i < 3; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      await context.reportProgress({
+        progress: (i + 1) * 33,
+        total: 100,
+      } as Progress);
+    }
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Hello from ${user.framework}, ${user.name}!`,
+        },
+      ],
+    };
+  }
+
+  @Tool({
+    name: 'framework-detector',
+    description: 'Detects which HTTP framework is being used',
+    parameters: z.object({}),
+  })
+  async detectFramework() {
+    // For testing purposes, we'll identify the framework based on the tool behavior
+    // In a real implementation, the adapter factory would handle this automatically
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Framework detection test - adapter working correctly`,
+        },
+      ],
+    };
+  }
+}
+
+@Injectable({ scope: Scope.REQUEST })
+export class RequestScopedTool {
+  @Tool({
+    name: 'request-scope-test',
+    description: 'Tests request scoping with Fastify',
+    parameters: z.object({
+      testId: z.string().default('test-123'),
+    }),
+  })
+  async testRequestScope({ testId }: { testId: string }) {
+    // Generate a unique ID to verify request scoping
+    const uniqueId = randomUUID();
+    
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Request-scoped response: testId=${testId}, uniqueId=${uniqueId}`,
+        },
+      ],
+    };
+  }
+}
+
+describe('E2E: Fastify HTTP Adapter Support', () => {
+  let expressApp: INestApplication;
+  let fastifyApp: INestApplication;
+  let expressPort: number;
+  let fastifyPort: number;
+
+  // Set timeout for all tests in this describe block
+  jest.setTimeout(20000);
+
+  beforeAll(async () => {
+    // Create Express-based server (control group)
+    const expressModuleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        McpModule.forRoot({
+          name: 'test-express-mcp-server',
+          version: '0.0.1',
+          transport: McpTransportType.STREAMABLE_HTTP,
+          streamableHttp: {
+            enableJsonResponse: false,
+            sessionIdGenerator: () => randomUUID(),
+            statelessMode: false,
+          },
+        }),
+      ],
+      providers: [
+        FastifyTestTool,
+        MockUserRepository,
+        RequestScopedTool,
+      ],
+    }).compile();
+
+    expressApp = expressModuleFixture.createNestApplication();
+    await expressApp.listen(0);
+
+    const expressServer = expressApp.getHttpServer();
+    if (!expressServer.address()) {
+      throw new Error('Express server address not found after listen');
+    }
+    expressPort = (expressServer.address() as import('net').AddressInfo).port;
+
+    // Create Fastify-based server (test subject)
+    let FastifyAdapter: any;
+    try {
+      const fastifyPlatform = await import('@nestjs/platform-fastify');
+      FastifyAdapter = fastifyPlatform.FastifyAdapter;
+    } catch (error) {
+      console.warn('Fastify not available, skipping Fastify-specific tests');
+      return;
+    }
+
+    const fastifyModuleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        McpModule.forRoot({
+          name: 'test-fastify-mcp-server',
+          version: '0.0.1',
+          transport: McpTransportType.STREAMABLE_HTTP,
+          streamableHttp: {
+            enableJsonResponse: false,
+            sessionIdGenerator: () => randomUUID(),
+            statelessMode: false,
+          },
+        }),
+      ],
+      providers: [
+        FastifyTestTool,
+        MockUserRepository,
+        RequestScopedTool,
+      ],
+    }).compile();
+
+    const fastifyAdapter = new FastifyAdapter();
+    fastifyApp = fastifyModuleFixture.createNestApplication(fastifyAdapter);
+    await fastifyApp.listen(0, '0.0.0.0');
+
+    const fastifyServer = fastifyApp.getHttpServer();
+    if (!fastifyServer.address()) {
+      throw new Error('Fastify server address not found after listen');
+    }
+    fastifyPort = (fastifyServer.address() as import('net').AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    if (expressApp) {
+      await expressApp.close();
+    }
+    if (fastifyApp) {
+      await fastifyApp.close();
+    }
+  });
+
+  describe('Express Server (Control)', () => {
+    let client: Client;
+
+    beforeEach(async () => {
+      if (!expressPort) {
+        throw new Error('Express server not available');
+      }
+      client = await createStreamableClient(expressPort);
+    });
+
+    afterEach(async () => {
+      if (client) {
+        await client.close();
+      }
+    });
+
+    it('should connect and list tools', async () => {
+      const toolsRequest: ListToolsRequest = {
+        method: 'tools/list',
+        params: {},
+      };
+      const toolsResult = await client.request(toolsRequest, ListToolsResultSchema);
+      
+      expect(toolsResult.tools).toBeDefined();
+      expect(toolsResult.tools.length).toBeGreaterThan(0);
+      
+      const toolNames = toolsResult.tools.map(tool => tool.name);
+      expect(toolNames).toContain('fastify-hello-world');
+      expect(toolNames).toContain('framework-detector');
+      expect(toolNames).toContain('request-scope-test');
+    });
+
+    it('should execute tools with Express', async () => {
+      const greetRequest: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'fastify-hello-world',
+          arguments: { name: 'Express Test' },
+        },
+      };
+
+      const result = await client.request(greetRequest, CallToolResultSchema);
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toContain('Hello from fastify, Fastify User Express Test!');
+    });
+
+    it('should detect Express framework', async () => {
+      const detectRequest: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'framework-detector',
+          arguments: {},
+        },
+      };
+
+      const result = await client.request(detectRequest, CallToolResultSchema);
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toContain('adapter working correctly');
+    });
+  });
+
+  describe('Fastify Server (Test Subject)', () => {
+    let client: Client;
+
+    beforeEach(async () => {
+      if (!fastifyPort) {
+        throw new Error('Fastify server not available - install @nestjs/platform-fastify to run these tests');
+      }
+      client = await createStreamableClient(fastifyPort);
+    });
+
+    afterEach(async () => {
+      if (client) {
+        await client.close();
+      }
+    });
+
+    it('should connect and list tools with Fastify', async () => {
+      const toolsRequest: ListToolsRequest = {
+        method: 'tools/list',
+        params: {},
+      };
+      const toolsResult = await client.request(toolsRequest, ListToolsResultSchema);
+      
+      expect(toolsResult.tools).toBeDefined();
+      expect(toolsResult.tools.length).toBeGreaterThan(0);
+      
+      const toolNames = toolsResult.tools.map(tool => tool.name);
+      expect(toolNames).toContain('fastify-hello-world');
+      expect(toolNames).toContain('framework-detector');
+      expect(toolNames).toContain('request-scope-test');
+    });
+
+    it('should execute tools with Fastify adapter', async () => {
+      const greetRequest: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'fastify-hello-world',
+          arguments: { name: 'Fastify Test' },
+        },
+      };
+
+      let progressReports = 0;
+      const result = await client.request(greetRequest, CallToolResultSchema, {
+        onprogress: (progress) => {
+          progressReports++;
+          expect(progress.progress).toBeGreaterThan(0);
+          expect(progress.total).toBe(100);
+        },
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toContain('Hello from fastify, Fastify User Fastify Test!');
+      expect(progressReports).toBeGreaterThan(0); // Verify progress reporting works
+    });
+
+    it('should detect Fastify framework', async () => {
+      const detectRequest: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'framework-detector',
+          arguments: {},
+        },
+      };
+
+      const result = await client.request(detectRequest, CallToolResultSchema);
+      expect(result.content).toBeDefined();
+      expect(result.content[0].text).toContain('adapter working correctly');
+    });
+
+    it('should handle request scoping correctly', async () => {
+      const testId1 = 'test-1';
+      const testId2 = 'test-2';
+
+      // Make two requests with different test IDs
+      const [result1, result2] = await Promise.all([
+        client.request({
+          method: 'tools/call',
+          params: {
+            name: 'request-scope-test',
+            arguments: { testId: testId1 },
+          },
+        }, CallToolResultSchema),
+        client.request({
+          method: 'tools/call',
+          params: {
+            name: 'request-scope-test',
+            arguments: { testId: testId2 },
+          },
+        }, CallToolResultSchema),
+      ]);
+
+      expect(result1.content[0].text).toContain(`testId=${testId1}`);
+      expect(result2.content[0].text).toContain(`testId=${testId2}`);
+      
+      // Extract unique IDs to verify they're different (proper request scoping)
+      const text1 = result1.content[0].text as string;
+      const text2 = result2.content[0].text as string;
+      const uniqueId1 = text1.match(/uniqueId=([^,\s]+)/)?.[1];
+      const uniqueId2 = text2.match(/uniqueId=([^,\s]+)/)?.[1];
+      
+      expect(uniqueId1).toBeDefined();
+      expect(uniqueId2).toBeDefined();
+      expect(uniqueId1).not.toBe(uniqueId2); // Different requests should have different UUIDs
+    });
+
+    it('should handle errors gracefully', async () => {
+      const invalidRequest: CallToolRequest = {
+        method: 'tools/call',
+        params: {
+          name: 'non-existent-tool',
+          arguments: {},
+        },
+      };
+
+      await expect(
+        client.request(invalidRequest, CallToolResultSchema)
+      ).rejects.toThrow();
+    });
+  });
+
+  describe('Framework Compatibility', () => {
+    it('should produce identical tool results regardless of framework', async () => {
+      if (!expressPort || !fastifyPort) {
+        console.warn('Skipping compatibility test - both servers not available');
+        return;
+      }
+
+      const expressClient = await createStreamableClient(expressPort);
+      const fastifyClient = await createStreamableClient(fastifyPort);
+
+      try {
+        // Test the same tool on both frameworks
+        const testArgs = { name: 'Compatibility Test' };
+        
+        const [expressResult, fastifyResult] = await Promise.all([
+          expressClient.request({
+            method: 'tools/call',
+            params: {
+              name: 'fastify-hello-world',
+              arguments: testArgs,
+            },
+          }, CallToolResultSchema),
+          fastifyClient.request({
+            method: 'tools/call',
+            params: {
+              name: 'fastify-hello-world',
+              arguments: testArgs,
+            },
+          }, CallToolResultSchema),
+        ]);
+
+        // Both should return the same type of response structure
+        expect(expressResult.content).toBeDefined();
+        expect(fastifyResult.content).toBeDefined();
+        expect(expressResult.content.length).toBe(fastifyResult.content.length);
+        
+        // Both should contain the expected content
+        expect(expressResult.content[0].text).toContain('Compatibility Test');
+        expect(fastifyResult.content[0].text).toContain('Compatibility Test');
+        
+      } finally {
+        await expressClient.close();
+        await fastifyClient.close();
+      }
+    });
+
+    it('should list identical tools on both frameworks', async () => {
+      if (!expressPort || !fastifyPort) {
+        console.warn('Skipping tools list compatibility test - both servers not available');
+        return;
+      }
+
+      const expressClient = await createStreamableClient(expressPort);
+      const fastifyClient = await createStreamableClient(fastifyPort);
+
+      try {
+        const [expressTools, fastifyTools] = await Promise.all([
+          expressClient.request({
+            method: 'tools/list',
+            params: {},
+          }, ListToolsResultSchema),
+          fastifyClient.request({
+            method: 'tools/list',
+            params: {},
+          }, ListToolsResultSchema),
+        ]);
+
+        // Both should have the same tools available
+        expect(expressTools.tools.length).toBe(fastifyTools.tools.length);
+        
+        const expressToolNames = expressTools.tools.map(t => t.name).sort();
+        const fastifyToolNames = fastifyTools.tools.map(t => t.name).sort();
+        
+        expect(expressToolNames).toEqual(fastifyToolNames);
+        
+      } finally {
+        await expressClient.close();
+        await fastifyClient.close();
+      }
+    });
+  });
+});

--- a/tests/mcp-resource.e2e.spec.ts
+++ b/tests/mcp-resource.e2e.spec.ts
@@ -3,7 +3,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Injectable } from '@nestjs/common';
 import { McpModule } from '../src/mcp.module';
 import { createSseClient } from './utils';
-import { Resource } from '../src';
+import { Resource, ResourceTemplate } from '../src';
 
 @Injectable()
 export class GreetingToolResource {
@@ -13,7 +13,7 @@ export class GreetingToolResource {
     name: 'hello-world',
     description: 'A simple greeting resource',
     mimeType: 'text/plain',
-    uri: 'mcp://hello-world',
+    uri: 'mcp://hello-world-world',
   })
   async sayHello({ uri }) {
     return {
@@ -27,11 +27,11 @@ export class GreetingToolResource {
     };
   }
 
-  @Resource({
+  @ResourceTemplate({
     name: 'hello-world-dynamic',
     description: 'A simple greeting dynamic resource',
     mimeType: 'text/plain',
-    uri: 'mcp://hello-world-dynamic/{userName}',
+    uriTemplate: 'mcp://hello-world-dynamic/{userName}',
   })
   async sayHelloDynamic({ uri, userName }) {
     return {
@@ -45,11 +45,11 @@ export class GreetingToolResource {
     };
   }
 
-  @Resource({
+  @ResourceTemplate({
     name: 'hello-world-dynamic-multiple-paths',
     description: 'A simple greeting dynamic resource with multiple paths',
     mimeType: 'text/plain',
-    uri: 'mcp://hello-world-dynamic-multiple-paths/{userId}/{userName}',
+    uriTemplate: 'mcp://hello-world-dynamic-multiple-paths/{userId}/{userName}',
   })
   async sayHelloMultiplePathsDynamic({ uri, userId, userName }) {
     return {
@@ -63,11 +63,11 @@ export class GreetingToolResource {
     };
   }
 
-  @Resource({
+  @ResourceTemplate({
     name: 'hello-world-dynamic-multiple-paths-error',
     description: 'A simple greeting dynamic resource with multiple paths',
     mimeType: 'text/plain',
-    uri: 'mcp://hello-world-dynamic-multiple-paths-error/{userId}/{userName}',
+    uriTemplate: 'mcp://hello-world-dynamic-multiple-paths-error/{userId}/{userName}',
   })
   async sayHelloMultiplePathsDynamicError() {
     throw new Error('any error');
@@ -104,19 +104,20 @@ describe('E2E: MCP Resource Server', () => {
   it('should list resources', async () => {
     const client = await createSseClient(testPort);
     const resources = await client.listResources();
+    const resourceTemplates = await client.listResourceTemplates();
 
     expect(resources.resources.find((r) => r.name === 'hello-world')).toEqual({
       name: 'hello-world',
-      uri: 'mcp://hello-world',
+      uri: 'mcp://hello-world-world',
       description: 'A simple greeting resource',
       mimeType: 'text/plain',
     });
 
     expect(
-      resources.resources.find((r) => r.name === 'hello-world-dynamic'),
+      resourceTemplates.resourceTemplates.find((r) => r.name === 'hello-world-dynamic'),
     ).toEqual({
       name: 'hello-world-dynamic',
-      uri: 'mcp://hello-world-dynamic/{userName}',
+      uriTemplate: 'mcp://hello-world-dynamic/{userName}',
       description: 'A simple greeting dynamic resource',
       mimeType: 'text/plain',
     });
@@ -124,18 +125,34 @@ describe('E2E: MCP Resource Server', () => {
     await client.close();
   });
 
-  it('should call the dynamic resource', async () => {
+    it('should call the static resource', async () => {
     const client = await createSseClient(testPort);
 
-    const result: any = await client.readResource({
-      uri: 'mcp://hello-world-dynamic/Raphael_John',
+    const result = await client.readResource({
+      uri: 'mcp://hello-world-world',
     });
 
     expect(result.contents[0].uri).toBe(
-      'mcp://hello-world-dynamic/Raphael_John',
+      'mcp://hello-world-world',
     );
     expect(result.contents[0].mimeType).toBe('text/plain');
-    expect(result.contents[0].text).toBe('Hello Raphael_John');
+    expect(result.contents[0].text).toBe('Hello World');
+
+    await client.close();
+  });
+
+  it('should call the dynamic resource', async () => {
+    const client = await createSseClient(testPort);
+
+    const result = await client.readResource({
+      uri: 'mcp://hello-world-dynamic/Raphael',
+    });
+
+    expect(result.contents[0].uri).toBe(
+      'mcp://hello-world-dynamic/Raphael',
+    );
+    expect(result.contents[0].mimeType).toBe('text/plain');
+    expect(result.contents[0].text).toBe('Hello Raphael');
 
     await client.close();
   });
@@ -143,7 +160,7 @@ describe('E2E: MCP Resource Server', () => {
   it('should call the dynamic resource with multiple paths', async () => {
     const client = await createSseClient(testPort);
 
-    const result: any = await client.readResource({
+    const result = await client.readResource({
       uri: 'mcp://hello-world-dynamic-multiple-paths/123/Raphael_John',
     });
 

--- a/tests/mcp-resource.e2e.spec.ts
+++ b/tests/mcp-resource.e2e.spec.ts
@@ -145,14 +145,14 @@ describe('E2E: MCP Resource Server', () => {
     const client = await createSseClient(testPort);
 
     const result = await client.readResource({
-      uri: 'mcp://hello-world-dynamic/Raphael',
+      uri: 'mcp://hello-world-dynamic/Raphael_John',
     });
 
     expect(result.contents[0].uri).toBe(
-      'mcp://hello-world-dynamic/Raphael',
+      'mcp://hello-world-dynamic/Raphael_John',
     );
     expect(result.contents[0].mimeType).toBe('text/plain');
-    expect(result.contents[0].text).toBe('Hello Raphael');
+    expect(result.contents[0].text).toBe('Hello Raphael_John');
 
     await client.close();
   });


### PR DESCRIPTION
Added fastify support by adding an abstraction layer for the request and response objects. This uses the adapter pattern that automatically detects if the server is running with express or fastify.

Added `@nestjs/platform-fastify` as an optional peer dependency.

### HTTP Adapter Pattern

The transport layer uses an adapter pattern to abstract away framework-specific differences:

- **`HttpAdapterFactory`** - Detects the framework and returns the appropriate adapter
- **`ExpressHttpAdapter`** - Handles Express request/response objects
- **`FastifyHttpAdapter`** - Handles Fastify request/reply objects
- **Generic interfaces** - `HttpRequest` and `HttpResponse` provide a unified API

### Automatic Detection

The factory automatically detects the framework by examining the request and response objects:

**Express Detection:**
- Has `req.get()` method
- No `req.routeOptions` property
- Response has `headersSent` property
- No `res.sent` property

**Fastify Detection:**
- Has `req.routeOptions` property
- Response has `res.sent` property
- Response has `res.header()` method


Currently this also includes the changes from https://github.com/rekog-labs/MCP-Nest/pull/94 as I can't create stacked PR's from my fork. So please check that one first.