### PR TITLE
feat(mcp): expose getMcpModuleIds in McpRegistryService

### DIFF
--- a/src/mcp/services/mcp-registry.service.ts
+++ b/src/mcp/services/mcp-registry.service.ts
@@ -269,6 +269,13 @@ export class McpRegistryService implements OnApplicationBootstrap {
   }
 
   /**
+   * Return all discovered MCP module IDs
+   */
+  getMcpModuleIds(): string[] {
+    return Array.from(this.discoveredToolsByMcpModuleId.keys());
+  }
+
+  /**
    * Get all discovered tools
    */
   getTools(mcpModuleId: string): DiscoveredTool<ToolMetadata>[] {


### PR DESCRIPTION
Expose getMcpModuleIds() on McpRegistryService to retrieve all discovered MCP module IDs.

Rationale:

- Simplifies introspection across multiple MCP servers discovered under different module roots.

- Non-breaking: adds a single accessor; does not modify discovery behavior.

Implementation:

Adds getMcpModuleIds(): returns Array.from(discoveredToolsByMcpModuleId.keys()).