### PR TITLE
support for custom controllers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # NestJS MCP Server Module
 
 ## Project Overview
-This is `@rekog/mcp-nest`, a NestJS module that transforms NestJS applications into Model Context Protocol (MCP) servers. It exposes tools, resources, and prompts for AI consumption via decorators, supporting multiple transport protocols (HTTP+SSE, Streamable HTTP, STDIO).
+This is `@rekog/mcp-nest`, a NestJS module that transforms NestJS applications into Model Context Protocol (MCP) servers. It exposes tools, resources, and prompts for AI consumption via decorators, supporting multiple transport protocols (HTTP+SSE, Streamable HTTP, STDIO) with optional OAuth 2.1 authentication.
 
 ## Essential Development Commands
 
@@ -34,10 +34,51 @@ npx --node-options=--experimental-vm-modules jest tests/mcp-tool.e2e.spec.ts
 npx --node-options=--experimental-vm-modules jest --testNamePattern="auth"
 ```
 
-## Core Architecture Patterns
+## Core Components
 
-### 1. Decorator-Based Registration System
-Tools, resources, and prompts are discovered through decorators using NestJS's reflection capabilities:
+### 1. McpModule - The Primary MCP Server Module
+Located at `src/mcp/mcp.module.ts:18`. This is the main module for creating MCP servers.
+
+**Key Features**:
+- Decorator-based tool/resource/prompt discovery via `McpRegistryService`
+- Multi-transport support (HTTP+SSE, Streamable HTTP, STDIO)
+- Dynamic controller generation for different transport types
+- Module instance isolation with unique `moduleId` per `forRoot()` call
+
+**Basic Usage**:
+```typescript
+McpModule.forRoot({
+  name: 'my-mcp-server',
+  version: '1.0.0',
+  transport: [McpTransportType.SSE, McpTransportType.STREAMABLE_HTTP],
+  guards: [SomeGuard], // Optional authentication
+})
+```
+
+### 2. McpAuthModule - OAuth 2.1 Authorization Server
+Located at `src/authz/mcp-oauth.module.ts:76`. Provides complete OAuth 2.1 compliant Identity Provider implementation.
+
+**Key Features**:
+- Built-in GitHub and Google OAuth providers
+- Multiple storage backends (memory, TypeORM, custom)
+- MCP Authorization specification compliance (2025-06-18)
+- Dynamic client registration (RFC 7591)
+- PKCE support and comprehensive token validation
+
+**Basic Usage**:
+```typescript
+McpAuthModule.forRoot({
+  provider: GitHubOAuthProvider,
+  clientId: process.env.GITHUB_CLIENT_ID!,
+  clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+  jwtSecret: process.env.JWT_SECRET!,
+  serverUrl: 'http://localhost:3030',
+  apiPrefix: 'auth',
+})
+```
+
+### 3. Tool Definition Pattern
+Tools are defined using decorators with three-parameter method signature:
 
 ```typescript
 @Injectable()
@@ -56,130 +97,146 @@ export class MyService {
 }
 ```
 
-**Key Pattern**: Method signature is `(args, context, httpRequest)` where:
-- `args`: Zod-validated parameters
+**Method Parameters**:
+- `args`: Zod-validated parameters from tool call
 - `context`: MCP context with `reportProgress`, `mcpServer`, `mcpRequest`, logging
-- `httpRequest`: HTTP request object (undefined for STDIO)
+- `request`: HTTP request object (undefined for STDIO transport)
 
-### 2. Multi-Transport Architecture
-Three transport types with different controllers:
+### 4. Transport Architecture
+Three transport types with dynamic controller creation:
 - **SSE**: `createSseController()` - GET `/sse` + POST `/messages`
 - **Streamable HTTP**: `createStreamableHttpController()` - POST `/mcp` (+ GET/DELETE for stateful)
-- **STDIO**: `StdioService` - No HTTP endpoints
+- **STDIO**: `StdioService` - No HTTP endpoints, uses standard input/output
 
-Each transport creates dynamic controllers via factory functions in `McpModule.forRoot()`.
+Controllers are generated dynamically in `McpModule.forRoot()` based on transport configuration.
 
-### 3. Request Scoping & Dependency Injection
-Uses NestJS's request scoping for per-request instances:
+### 5. Module Integration Pattern
+Both modules work together for authenticated MCP servers:
+
 ```typescript
-@Injectable({ scope: Scope.REQUEST })
-export class RequestScopedService {
-  constructor(@Inject(REQUEST) private request: Request) {}
-}
+@Module({
+  imports: [
+    McpAuthModule.forRoot({ /* OAuth config */ }),
+    McpModule.forRoot({
+      guards: [McpAuthJwtGuard], // Links auth to MCP
+      /* other MCP config */
+    }),
+  ],
+  providers: [McpAuthJwtGuard],
+})
+class AppModule {}
 ```
 
-The `McpExecutorService` (REQUEST-scoped) orchestrates handler registration per request.
+## Documentation Structure
+The project maintains comprehensive documentation in the `docs/` directory:
 
-### 4. Module Instance Isolation
-Each `McpModule.forRoot()` call creates a unique module instance with its own `moduleId`:
+### Core Guides
+- `docs/tools.md` - Tool creation, parameters, progress reporting, elicitation
+- `docs/resources.md` - Static and dynamic content serving
+- `docs/resource-templates.md` - Parameterized resource URIs
+- `docs/prompts.md` - Reusable prompt templates
+- `docs/server-examples.md` - Complete server configurations and transport examples
+- `docs/dependency-injection.md` - NestJS DI patterns within MCP context
+
+### Authorization Documentation
+- `docs/built-in-authorization-server.md` - Complete McpAuthModule usage and configuration
+- `docs/external-authorization-server/README.md` - External OAuth server integration
+
+## Key Implementation Details
+
+### Module Instance Isolation
+Each `McpModule.forRoot()` creates isolated instances with unique `moduleId`:
 ```typescript
 const moduleId = `mcp-module-${instanceIdCounter++}`;
 ```
-This enables multiple MCP servers in one application with different endpoints/capabilities.
+This enables multiple MCP servers in one application with different capabilities.
 
-## Testing Patterns
-
-### E2E Test Structure
-The test suite comprehensively covers all transport types:
-- E2E tests create actual NestJS apps with different transport configurations
-- Tests run the same scenarios across HTTP+SSE, Streamable HTTP (stateful/stateless), and STDIO
-- Use `createSseClient()`, `createStreamableClient()`, `createStdioClient()` helpers
-
-### Test File Patterns
-- `*.e2e.spec.ts` - End-to-end integration tests
-- `*.spec.ts` - Unit tests
-- All tests require `--node-options=--experimental-vm-modules` flag
-
-## Critical Implementation Details
+### Request Scoping & Discovery
+- `McpRegistryService` discovers decorated methods at bootstrap using `DiscoveryService`
+- `McpExecutorService` (REQUEST-scoped) handles per-request tool execution
+- Registry maintains maps by `mcpModuleId` for isolation
 
 ### Output Schema Validation
-Tools with `outputSchema` get validated results. Failed validation throws `McpError`:
+Tools with `outputSchema` validate results, throwing `McpError` on failure:
 ```typescript
 if (outputSchema) {
   const validation = outputSchema.safeParse(result);
   if (!validation.success) {
     throw new McpError(ErrorCode.InternalError, `Tool result does not match outputSchema`);
   }
-  return { structuredContent: result, content: this.buildDefaultContentBlock(result) };
 }
 ```
 
-### Resource URI Matching
-Resources use `path-to-regexp` for dynamic URI matching:
+### Resource URI Templates
+Resources use `path-to-regexp` for dynamic URIs:
 - Static: `uri: 'mcp://hello-world'`
 - Template: `uriTemplate: 'mcp://hello-world/{userId}/{userName}'`
 
-Templates extract parameters using `match()` function with URL decoding.
+### OAuth Store Configuration
+McpAuthModule supports multiple storage backends:
+- Memory store (default, testing)
+- TypeORM store (production, with unique connection name to avoid clashes)
+- Custom store implementation via `IOAuthStore` interface
 
-### Authentication Integration
-Guards apply to all MCP endpoints:
-```typescript
-McpModule.forRoot({
-  guards: [AuthGuard], // Applied to SSE/messages/mcp endpoints
-})
-```
-Request context flows through to tools via dependency injection.
+## Testing Patterns
+- E2E tests create actual NestJS apps with different transport configurations
+- Tests run scenarios across HTTP+SSE, Streamable HTTP (stateful/stateless), and STDIO
+- All tests require `--node-options=--experimental-vm-modules` flag
+- Use client helpers: `createSseClient()`, `createStreamableClient()`, `createStdioClient()`
 
-## Project-Specific Conventions
+## Project Structure
 
 ### File Organization
-- `src/mcp/` - Core MCP functionality
-- `src/authz/` - OAuth authentication module  
+- `src/mcp/` - Core MCP functionality (McpModule, transports, services)
+- `src/authz/` - OAuth authentication module (McpAuthModule)
 - `src/mcp/decorators/` - Tool/Resource/Prompt decorators
-- `src/mcp/services/handlers/` - Protocol request handlers
-- `src/mcp/transport/` - Transport implementations
-- `playground/` - Working examples
-- `tests/` - Comprehensive E2E test suite
-
-### Error Handling Patterns
-MCP tools should return standardized error format:
-```typescript
-return {
-  content: [{ type: 'text', text: error.message }],
-  isError: true,
-};
-```
-
-### Registry Service Pattern
-`McpRegistryService` discovers decorated methods at bootstrap using `DiscoveryService` and `MetadataScanner`. It maintains maps by `mcpModuleId` for isolation.
+- `src/mcp/services/handlers/` - MCP protocol request handlers
+- `src/mcp/transport/` - Transport implementations (SSE, Streamable HTTP, STDIO)
+- `src/authz/providers/` - OAuth providers (GitHub, Google, custom interface)
+- `src/authz/stores/` - Storage backends (memory, TypeORM, custom interface)
+- `playground/` - Working examples and demo servers
+- `tests/` - Comprehensive E2E test suite covering all transports
+- `docs/` - Complete documentation for all features
 
 ### HTTP Adapter Abstraction
-`HttpAdapterFactory` provides framework-agnostic request/response handling for Express/Fastify compatibility.
+`HttpAdapterFactory` at `src/mcp/adapters/` provides framework-agnostic request/response handling for Express/Fastify compatibility.
 
-## Key Integration Points
+## Integration Points
 
 ### With NestJS Ecosystem
-- Full DI container integration
-- Guard/Interceptor support
-- Request scoping
-- Module system
-- Versioning compatibility (VERSION_NEUTRAL)
+- Full dependency injection container integration
+- Guard/Interceptor support for authentication
+- Request scoping for per-request instances
+- Module system with dynamic module configuration
+- Compatibility with NestJS versioning (VERSION_NEUTRAL)
 
 ### With MCP SDK
-- Wraps `@modelcontextprotocol/sdk` transports
-- Handles MCP protocol schemas
-- Progress reporting via context
-- Elicitation support for interactive tools
+- Wraps `@modelcontextprotocol/sdk` for transport layer
+- Handles MCP protocol message schemas
+- Progress reporting via context object
+- Elicitation support for interactive tool calls
 
 ### External Dependencies
-- `zod` for parameter validation
-- `path-to-regexp` for URI matching
-- `zod-to-json-schema` for OpenAPI-style schemas
+- `@modelcontextprotocol/sdk` - Core MCP protocol implementation
+- `zod` - Parameter validation and schema definition
+- `path-to-regexp` - Dynamic URI matching for resource templates
+- `zod-to-json-schema` - Schema conversion for tool parameters
+- `passport` + provider strategies - OAuth authentication
+- `@nestjs/jwt` - JWT token management
+- `typeorm` (optional) - Database storage for OAuth data
 
-## Important Notes from Copilot Instructions
+## Key Architecture Principles
 
-- This module transforms NestJS services into MCP servers through decorators, not the other way around
-- The NestJS application hosts the MCP server, making existing business logic available to AI systems
-- Each `McpModule.forRoot()` creates an isolated instance with unique endpoints
-- Authentication uses standard NestJS Guards applied at the transport level
-- Progress reporting is handled through the MCP context object passed to tools
+### Transform Pattern
+The module transforms existing NestJS services into MCP servers through decorators, making business logic available to AI systems without modification.
+
+### Transport Agnostic
+Each `McpModule.forRoot()` can serve multiple transport protocols simultaneously, with clients choosing their preferred connection method.
+
+### Security Integration
+Authentication is handled at the transport level via NestJS Guards, ensuring all MCP endpoints respect the same security policies as the rest of the application.
+
+### Stateful vs Stateless
+Supports both stateful (session-based) and stateless operation modes, with configurable session ID generation for multi-user scenarios.
+
+- don't run linting, I don't care about it or formatting

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,10 @@
 - [Resources Guide](./resources.md) — Defining and exposing resources.
 - [Dependency Injection](docs/dependency-injection.md) — Leverage NestJS DI system throughout MCP components.
 
+### Advanced Usage
+
+- [Advanced Server Pattern](../playground/servers/advanced/README.md) — Direct service usage with custom controllers for maximum control over interceptors, guards, middleware, and endpoint configuration.
+
 ### OAuth & Authorization
 
 - [Built-in Authorization Server](./built-in-authorization-server.md) — Using the built-in Authorization Server for simpler setups.

--- a/playground/servers/advanced/README.md
+++ b/playground/servers/advanced/README.md
@@ -1,0 +1,79 @@
+# Advanced MCP Server Pattern
+
+This pattern demonstrates how to bypass the automatic controller factories and use MCP services (`McpSseService` and `McpStreamableHttpService`) directly in custom controllers for maximum control over your MCP server endpoints.
+
+## When to Use This Pattern
+
+Use this approach when you need:
+- **Custom middleware**: Apply specific interceptors, guards, or pipes to MCP endpoints
+- **Custom routing**: Define non-standard endpoint paths or add additional route parameters
+- **Enhanced security**: Apply authentication/authorization at the controller level
+- **Multiple configurations**: Use the same services with different endpoint configurations
+- **Fine-grained control**: Full control over request/response handling beyond what the factories provide
+
+## How to Implement
+
+### Step 1: Disable Auto-Generated Controllers
+
+Configure `McpModule.forRoot()` with empty transport array to disable automatic controller generation:
+
+```typescript
+McpModule.forRoot({
+  name: 'my-server',
+  version: '1.0.0',
+  transport: [], // Disable all automatic controller generation
+})
+```
+
+### Step 2: Create Custom Controllers
+
+Define your controllers and inject the services:
+
+```typescript
+@Controller()
+export class MyCustomSseController {
+  constructor(private readonly mcpSseService: McpSseService) {}
+
+  @Get('/my-custom-sse')
+  @UseGuards(MyCustomGuard) // Apply custom guards
+  async handleSse(@Req() req, @Res() res) {
+    return this.mcpSseService.createSseConnection(req, res, 'messages', '');
+  }
+}
+```
+
+## Running the Example
+
+```bash
+npx ts-node-dev --respawn playground/servers/advanced/server-advanced.ts
+```
+
+## Testing with MCP Inspector
+
+The server exposes standard MCP endpoints that can be tested with [MCP Inspector](https://github.com/modelcontextprotocol/inspector):
+
+- **SSE Transport**: `http://localhost:3030/sse`
+- **Streamable HTTP Transport**: `http://localhost:3030/mcp`
+
+Use MCP Inspector to connect to either endpoint and test tool calls, resource requests, and prompt interactions.
+
+## Example Files
+
+- `server-advanced.ts` - Complete server setup with disabled transports and manual service registration
+- `sse.controller.ts` - Custom SSE controller implementation
+- `streamable-http.controller.ts` - Custom Streamable HTTP controller implementation
+
+## Key Implementation Details
+
+### Controller Delegation Pattern
+
+Controllers act as thin HTTP wrappers that delegate to the services:
+
+```typescript
+@Post('/messages')
+async handleMessages(@Req() req, @Res() res, @Body() body) {
+  await this.mcpSseService.handleMessage(req, res, body);
+}
+```
+
+This maintains separation of concerns while giving you full control over the HTTP layer.

--- a/playground/servers/advanced/server-advanced.ts
+++ b/playground/servers/advanced/server-advanced.ts
@@ -1,0 +1,37 @@
+import { Module } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { McpModule } from '../../../src/mcp/mcp.module';
+import { GreetingPrompt } from '../../resources/greeting.prompt';
+import { GreetingResource } from '../../resources/greeting.resource';
+import { GreetingTool } from '../../resources/greeting.tool';
+import { SseController } from './sse.controller';
+import { StreamableHttpController } from './streamable-http.controller';
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'advanced-mcp-server',
+      version: '1.0.0',
+      transport: [], // Disable all default transports
+    }),
+  ],
+  controllers: [SseController, StreamableHttpController],
+  providers: [GreetingTool, GreetingResource, GreetingPrompt],
+})
+class AppModule {}
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  const port = process.env.PORT || 3030;
+
+  await app.listen(port);
+  console.log(`Advanced MCP server is running on http://localhost:${port}`);
+  console.log('Available endpoints:');
+  console.log('- GET /sse - SSE connection');
+  console.log('- POST /messages - SSE message handling');
+  console.log('- POST /mcp - Streamable HTTP (main endpoint)');
+  console.log('- GET /mcp - Streamable HTTP SSE stream');
+  console.log('- DELETE /mcp - Streamable HTTP session termination');
+}
+
+void bootstrap();

--- a/playground/servers/advanced/sse.controller.ts
+++ b/playground/servers/advanced/sse.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Logger,
+  OnModuleInit,
+  Post,
+  Req,
+  Res,
+  VERSION_NEUTRAL,
+} from '@nestjs/common';
+
+import { McpSseService } from '../../../src/mcp/services/mcp-sse.service';
+import { normalizeEndpoint } from '../../../src/mcp/utils/normalize-endpoint';
+
+/**
+ * Advanced SSE Controller - Direct use of McpSseService
+ * This controller demonstrates how to use McpSseService directly
+ * instead of relying on the factory pattern
+ */
+@Controller({
+  version: VERSION_NEUTRAL,
+})
+export class SseController implements OnModuleInit {
+  readonly logger = new Logger(SseController.name);
+
+  constructor(public readonly mcpSseService: McpSseService) {}
+
+  /**
+   * Initialize the controller and configure SSE service
+   */
+  onModuleInit() {
+    this.mcpSseService.initialize();
+  }
+
+  /**
+   * SSE connection endpoint
+   */
+  @Get('/sse')
+  async sse(@Req() rawReq: any, @Res() rawRes: any) {
+    return this.mcpSseService.createSseConnection(
+      rawReq,
+      rawRes,
+      'messages',
+      '', // api prefix
+    );
+  }
+
+  /**
+   * Tool execution endpoint
+   */
+  @Post('/messages')
+  async messages(
+    @Req() rawReq: any,
+    @Res() rawRes: any,
+    @Body() body: unknown,
+  ): Promise<void> {
+    await this.mcpSseService.handleMessage(rawReq, rawRes, body);
+  }
+}

--- a/playground/servers/advanced/streamable-http.controller.ts
+++ b/playground/servers/advanced/streamable-http.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Logger,
+  Post,
+  Req,
+  Res,
+} from '@nestjs/common';
+
+import { McpStreamableHttpService } from '../../../src/mcp/services/mcp-streamable-http.service';
+
+/**
+ * Advanced Streamable HTTP Controller - Direct use of McpStreamableHttpService
+ * This controller demonstrates how to use McpStreamableHttpService directly
+ * instead of relying on the factory pattern
+ */
+@Controller()
+export class StreamableHttpController {
+  public readonly logger = new Logger(StreamableHttpController.name);
+
+  constructor(
+    public readonly mcpStreamableHttpService: McpStreamableHttpService,
+  ) {}
+
+  /**
+   * Main HTTP endpoint for both initialization and subsequent requests
+   */
+  @Post('/mcp')
+  async handlePostRequest(
+    @Req() req: any,
+    @Res() res: any,
+    @Body() body: unknown,
+  ): Promise<void> {
+    await this.mcpStreamableHttpService.handlePostRequest(req, res, body);
+  }
+
+  /**
+   * GET endpoint for SSE streams - not supported in stateless mode
+   */
+  @Get('/mcp')
+  async handleGetRequest(@Req() req: any, @Res() res: any): Promise<void> {
+    await this.mcpStreamableHttpService.handleGetRequest(req, res);
+  }
+
+  /**
+   * DELETE endpoint for terminating sessions - not supported in stateless mode
+   */
+  @Delete('/mcp')
+  async handleDeleteRequest(@Req() req: any, @Res() res: any): Promise<void> {
+    await this.mcpStreamableHttpService.handleDeleteRequest(req, res);
+  }
+}

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -3,3 +3,5 @@ export * from './interfaces';
 export * from './mcp.module';
 export * from './services/mcp-registry.service';
 export * from './services/mcp-executor.service';
+export * from './services/mcp-sse.service';
+export * from './services/mcp-streamable-http.service';

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -3,6 +3,8 @@ import { DiscoveryModule } from '@nestjs/core';
 import { McpOptions, McpTransportType } from './interfaces';
 import { McpExecutorService } from './services/mcp-executor.service';
 import { McpRegistryService } from './services/mcp-registry.service';
+import { McpSseService } from './services/mcp-sse.service';
+import { McpStreamableHttpService } from './services/mcp-streamable-http.service';
 import { SsePingService } from './services/sse-ping.service';
 import { createSseController } from './transport/sse.controller.factory';
 import { StdioService } from './transport/stdio.service';
@@ -57,7 +59,7 @@ export class McpModule {
       module: McpModule,
       controllers,
       providers,
-      exports: [McpRegistryService],
+      exports: [McpRegistryService, McpSseService, McpStreamableHttpService],
     };
   }
 
@@ -118,19 +120,11 @@ export class McpModule {
       },
       McpRegistryService,
       McpExecutorService,
+      SsePingService,
+      McpSseService,
+      McpStreamableHttpService,
+      StdioService,
     ];
-
-    const transports = Array.isArray(options.transport)
-      ? options.transport
-      : [options.transport ?? McpTransportType.SSE];
-
-    if (transports.includes(McpTransportType.SSE)) {
-      providers.push(SsePingService);
-    }
-
-    if (transports.includes(McpTransportType.STDIO)) {
-      providers.push(StdioService);
-    }
 
     return providers;
   }

--- a/src/mcp/services/mcp-sse.service.ts
+++ b/src/mcp/services/mcp-sse.service.ts
@@ -1,0 +1,131 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ApplicationConfig, ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+import { buildMcpCapabilities } from '../utils/capabilities-builder';
+import { McpOptions } from '../interfaces';
+import { McpExecutorService } from './mcp-executor.service';
+import { McpRegistryService } from './mcp-registry.service';
+import { SsePingService } from './sse-ping.service';
+import { normalizeEndpoint } from '../utils/normalize-endpoint';
+import { HttpAdapterFactory } from '../adapters';
+
+@Injectable()
+export class McpSseService {
+  private readonly logger = new Logger(McpSseService.name);
+
+  // Note: Currently, storing transports and servers makes it a requirement to have sticky sessions.
+
+  // Map to store active transports by session ID
+  private readonly transports = new Map<string, SSEServerTransport>();
+  // Map to store MCP server instances by session ID
+  private readonly mcpServers = new Map<string, McpServer>();
+
+  constructor(
+    @Inject('MCP_OPTIONS') private readonly options: McpOptions,
+    @Inject('MCP_MODULE_ID') private readonly mcpModuleId: string,
+    private readonly applicationConfig: ApplicationConfig,
+    private readonly moduleRef: ModuleRef,
+    private readonly toolRegistry: McpRegistryService,
+    @Inject(SsePingService) private readonly pingService: SsePingService,
+  ) {}
+
+  /**
+   * Initialize the SSE service and configure ping service
+   */
+  initialize() {
+    // Configure ping service with options
+    this.pingService.configure({
+      pingEnabled: this.options.sse?.pingEnabled, // Enable by default
+      pingIntervalMs: this.options.sse?.pingIntervalMs,
+    });
+  }
+
+  /**
+   * Create and manage SSE connection
+   */
+  async createSseConnection(
+    rawReq: any,
+    rawRes: any,
+    messagesEndpoint: string,
+    apiPrefix: string,
+  ): Promise<void> {
+    const adapter = HttpAdapterFactory.getAdapter(rawReq, rawRes);
+    const res = adapter.adaptResponse(rawRes);
+
+    // Create a new SSE transport instance
+    const transport = new SSEServerTransport(
+      normalizeEndpoint(
+        `${apiPrefix}/${this.applicationConfig.getGlobalPrefix()}/${messagesEndpoint}`,
+      ),
+      res.raw,
+    );
+    const sessionId = transport.sessionId;
+
+    // Create a new MCP server instance with dynamic capabilities
+    const capabilities = buildMcpCapabilities(
+      this.mcpModuleId,
+      this.toolRegistry,
+      this.options,
+    );
+    this.logger.debug('Built MCP capabilities:', capabilities);
+
+    // Create a new MCP server for this session with dynamic capabilities
+    const mcpServer = new McpServer(
+      { name: this.options.name, version: this.options.version },
+      {
+        capabilities,
+        instructions: this.options.instructions || '',
+      },
+    );
+
+    // Store the transport and server for this session
+    this.transports.set(sessionId, transport);
+    this.mcpServers.set(sessionId, mcpServer);
+
+    // Register the connection with the ping service
+    this.pingService.registerConnection(sessionId, transport, res);
+
+    transport.onclose = () => {
+      // Clean up when the connection closes
+      this.transports.delete(sessionId);
+      this.mcpServers.delete(sessionId);
+      this.pingService.removeConnection(sessionId);
+    };
+
+    await mcpServer.connect(transport);
+  }
+
+  /**
+   * Handle message processing for SSE
+   */
+  async handleMessage(rawReq: any, rawRes: any, body: unknown): Promise<any> {
+    const adapter = HttpAdapterFactory.getAdapter(rawReq, rawRes);
+    const req = adapter.adaptRequest(rawReq);
+    const res = adapter.adaptResponse(rawRes);
+    const sessionId = req.query.sessionId as string;
+    const transport = this.transports.get(sessionId);
+
+    if (!transport) {
+      return res.status(404).send('Session not found');
+    }
+
+    const mcpServer = this.mcpServers.get(sessionId);
+    if (!mcpServer) {
+      return res.status(404).send('MCP server not found for session');
+    }
+
+    // Resolve the request-scoped tool executor service
+    const contextId = ContextIdFactory.getByRequest(req);
+    const executor = await this.moduleRef.resolve(
+      McpExecutorService,
+      contextId,
+    );
+
+    // Register request handlers with the user context from this specific request
+    executor.registerRequestHandlers(mcpServer, req);
+
+    // Process the message
+    await transport.handlePostMessage(req.raw, res.raw, body);
+  }
+}

--- a/src/mcp/services/mcp-streamable-http.service.ts
+++ b/src/mcp/services/mcp-streamable-http.service.ts
@@ -1,0 +1,378 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { randomUUID } from 'crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { HttpAdapterFactory } from '../adapters/http-adapter.factory';
+import {
+  HttpRequest,
+  HttpResponse,
+} from '../interfaces/http-adapter.interface';
+import { McpOptions } from '../interfaces';
+import { McpExecutorService } from './mcp-executor.service';
+import { McpRegistryService } from './mcp-registry.service';
+import { buildMcpCapabilities } from '../utils/capabilities-builder';
+
+@Injectable()
+export class McpStreamableHttpService {
+  private readonly logger = new Logger(McpStreamableHttpService.name);
+  private readonly transports: {
+    [sessionId: string]: StreamableHTTPServerTransport;
+  } = {};
+  private readonly mcpServers: { [sessionId: string]: McpServer } = {};
+  private readonly isStatelessMode: boolean;
+
+  constructor(
+    @Inject('MCP_OPTIONS') private readonly options: McpOptions,
+    @Inject('MCP_MODULE_ID') private readonly mcpModuleId: string,
+    private readonly moduleRef: ModuleRef,
+    private readonly toolRegistry: McpRegistryService,
+  ) {
+    // Determine if we're in stateless mode
+    this.isStatelessMode = !!options.streamableHttp?.statelessMode;
+  }
+
+  /**
+   * Create a new MCP server instance for stateless requests
+   */
+  async createStatelessServer(rawReq: any): Promise<{
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+  }> {
+    // Create a new transport for this request
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse:
+        this.options.streamableHttp?.enableJsonResponse || false,
+    });
+
+    // Create a new MCP server instance with dynamic capabilities
+    const capabilities = buildMcpCapabilities(
+      this.mcpModuleId,
+      this.toolRegistry,
+      this.options,
+    );
+    this.logger.debug('Built MCP capabilities:', capabilities);
+
+    const server = new McpServer(
+      { name: this.options.name, version: this.options.version },
+      {
+        capabilities: capabilities,
+        instructions: this.options.instructions || '',
+      },
+    );
+
+    // Connect the transport to the MCP server first
+    await server.connect(transport);
+
+    // Now resolve the request-scoped tool executor service
+    const contextId = ContextIdFactory.getByRequest(rawReq);
+    const executor = await this.moduleRef.resolve(
+      McpExecutorService,
+      contextId,
+      { strict: true },
+    );
+
+    // Register request handlers after connection
+    this.logger.debug('Registering request handlers for stateless MCP server');
+    executor.registerRequestHandlers(server, rawReq);
+
+    return { server, transport };
+  }
+
+  /**
+   * Handle POST requests
+   */
+  async handlePostRequest(req: any, res: any, body: unknown): Promise<void> {
+    this.logger.debug('Received MCP request:', body);
+
+    // Get the appropriate HTTP adapter for the request/response
+    const adapter = HttpAdapterFactory.getAdapter(req, res);
+    const adaptedReq = adapter.adaptRequest(req);
+    const adaptedRes = adapter.adaptResponse(res);
+
+    try {
+      if (this.isStatelessMode) {
+        return this.handleStatelessRequest(adaptedReq, adaptedRes, body);
+      } else {
+        return this.handleStatefulRequest(adaptedReq, adaptedRes, body);
+      }
+    } catch (error) {
+      this.logger.error('Error handling MCP request:', error);
+      if (!adaptedRes.headersSent) {
+        adaptedRes.status(500).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32603,
+            message: 'Internal server error',
+          },
+          id: null,
+        });
+      }
+    }
+  }
+
+  /**
+   * Handle requests in stateless mode
+   */
+  async handleStatelessRequest(
+    req: any,
+    res: HttpResponse,
+    body: unknown,
+  ): Promise<void> {
+    this.logger.debug(
+      `Handling stateless MCP request at ${req.url} with body: ${JSON.stringify(
+        body,
+      )}`,
+    );
+
+    let server: McpServer | null = null;
+    let transport: StreamableHTTPServerTransport | null = null;
+
+    try {
+      // Create a new server and transport for each request
+      const stateless = await this.createStatelessServer(req);
+      server = stateless.server;
+      transport = stateless.transport;
+
+      // Handle the request
+      await transport.handleRequest(req.raw, res.raw, body);
+
+      // Clean up when the response closes
+      res.on?.('close', () => {
+        this.logger.debug('Stateless request closed, cleaning up');
+        void transport?.close();
+        void server?.close();
+      });
+    } catch (error) {
+      this.logger.error('Error in stateless request handling:', error);
+      // Clean up on error
+      void transport?.close();
+      void server?.close();
+      throw error;
+    }
+  }
+
+  /**
+   * Handle requests in stateful mode
+   */
+  async handleStatefulRequest(
+    req: HttpRequest,
+    res: HttpResponse,
+    body: unknown,
+  ): Promise<void> {
+    this.logger.debug(
+      `Handling stateful MCP request at ${req.url} with body: ${JSON.stringify(
+        body,
+      )}`,
+    );
+    // Check for existing session ID
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    let transport: StreamableHTTPServerTransport;
+
+    if (sessionId && this.transports[sessionId]) {
+      // Reuse existing transport
+      transport = this.transports[sessionId];
+    } else if (!sessionId && this.isInitializeRequest(body)) {
+      // New initialization request
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator:
+          this.options.streamableHttp?.sessionIdGenerator ||
+          (() => randomUUID()),
+        enableJsonResponse:
+          this.options.streamableHttp?.enableJsonResponse || false,
+        onsessioninitialized: (sessionId: string) => {
+          this.logger.debug(`Session initialized: ${sessionId}`);
+          this.transports[sessionId] = transport;
+        },
+      });
+
+      // Create a new MCP server for this session with dynamic capabilities
+      const capabilities = buildMcpCapabilities(
+        this.mcpModuleId,
+        this.toolRegistry,
+        this.options,
+      );
+      this.logger.debug('Built MCP capabilities:', capabilities);
+
+      const mcpServer = new McpServer(
+        { name: this.options.name, version: this.options.version },
+        {
+          capabilities,
+          instructions: this.options.instructions || '',
+        },
+      );
+
+      // Connect the transport to the MCP server BEFORE handling the request
+      await mcpServer.connect(transport);
+
+      // Handle the initialization request
+      await transport.handleRequest(req.raw, res.raw, body);
+
+      // Store the transport and server by session ID for future requests
+      if (transport.sessionId) {
+        this.transports[transport.sessionId] = transport;
+        this.mcpServers[transport.sessionId] = mcpServer;
+
+        // Set up cleanup when connection closes
+        transport.onclose = () => {
+          this.cleanupSession(transport.sessionId!);
+        };
+      }
+
+      this.logger.log(
+        `Initialized new session with ID: ${transport.sessionId}`,
+      );
+      return;
+    } else if (sessionId && !this.transports[sessionId]) {
+      // Provided session ID but no matching session exists
+      res.status(404).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Session not found',
+        },
+        id: null,
+      });
+      return;
+    } else {
+      // Invalid request - no session ID or not initialization request
+      res.status(400).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Bad Request: No valid session ID provided',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    // For subsequent requests to an existing session
+    const mcpServer = this.mcpServers[sessionId];
+    if (!mcpServer) {
+      res.status(404).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Session not found',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    // Resolve the request-scoped tool executor service
+    const contextId = ContextIdFactory.getByRequest(req);
+    const executor = await this.moduleRef.resolve(
+      McpExecutorService,
+      contextId,
+      { strict: true },
+    );
+
+    // Register request handlers with the user context from this specific request
+    executor.registerRequestHandlers(mcpServer, req);
+
+    // Handle the request with existing transport
+    await transport.handleRequest(req.raw, res.raw, body);
+  }
+
+  /**
+   * Handle GET requests for SSE streams
+   */
+  async handleGetRequest(req: any, res: any): Promise<void> {
+    // Get the appropriate HTTP adapter for the request/response
+    const adapter = HttpAdapterFactory.getAdapter(req, res);
+    const adaptedReq = adapter.adaptRequest(req);
+    const adaptedRes = adapter.adaptResponse(res);
+
+    if (this.isStatelessMode) {
+      adaptedRes.status(405).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Method not allowed in stateless mode',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    const sessionId = adaptedReq.headers['mcp-session-id'] as
+      | string
+      | undefined;
+
+    if (!sessionId || !this.transports[sessionId]) {
+      adaptedRes.status(400).send('Invalid or missing session ID');
+      return;
+    }
+
+    this.logger.debug(`Establishing SSE stream for session ${sessionId}`);
+    const transport = this.transports[sessionId];
+    await transport.handleRequest(adaptedReq.raw, adaptedRes.raw);
+  }
+
+  /**
+   * Handle DELETE requests for terminating sessions
+   */
+  async handleDeleteRequest(req: any, res: any): Promise<void> {
+    // Get the appropriate HTTP adapter for the request/response
+    const adapter = HttpAdapterFactory.getAdapter(req, res);
+    const adaptedReq = adapter.adaptRequest(req);
+    const adaptedRes = adapter.adaptResponse(res);
+
+    if (this.isStatelessMode) {
+      adaptedRes.status(405).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Method not allowed in stateless mode',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    const sessionId = adaptedReq.headers['mcp-session-id'] as
+      | string
+      | undefined;
+
+    if (!sessionId || !this.transports[sessionId]) {
+      adaptedRes.status(400).send('Invalid or missing session ID');
+      return;
+    }
+
+    this.logger.debug(`Terminating session ${sessionId}`);
+    const transport = this.transports[sessionId];
+    await transport.handleRequest(adaptedReq.raw, adaptedRes.raw);
+    this.cleanupSession(sessionId);
+  }
+
+  // Helper function to detect initialize requests
+  isInitializeRequest(body: unknown): boolean {
+    if (Array.isArray(body)) {
+      return body.some(
+        (msg) =>
+          typeof msg === 'object' &&
+          msg !== null &&
+          'method' in msg &&
+          msg.method === 'initialize',
+      );
+    }
+    return (
+      typeof body === 'object' &&
+      body !== null &&
+      'method' in body &&
+      body.method === 'initialize'
+    );
+  }
+
+  // Clean up session resources
+  cleanupSession(sessionId: string): void {
+    if (sessionId) {
+      this.logger.debug(`Cleaning up session: ${sessionId}`);
+      delete this.transports[sessionId];
+      delete this.mcpServers[sessionId];
+    }
+  }
+}

--- a/src/mcp/transport/streamable-http.controller.factory.ts
+++ b/src/mcp/transport/streamable-http.controller.factory.ts
@@ -13,20 +13,9 @@ import {
   UseGuards,
   applyDecorators,
 } from '@nestjs/common';
-import { ContextIdFactory, ModuleRef } from '@nestjs/core';
-import { randomUUID } from 'crypto';
 
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { HttpAdapterFactory } from '../adapters/http-adapter.factory';
-import {
-  HttpRequest,
-  HttpResponse,
-} from '../interfaces/http-adapter.interface';
 import { McpOptions } from '../interfaces';
-import { McpExecutorService } from '../services/mcp-executor.service';
-import { McpRegistryService } from '../services/mcp-registry.service';
-import { buildMcpCapabilities } from '../utils/capabilities-builder';
+import { McpStreamableHttpService } from '../services/mcp-streamable-http.service';
 import { normalizeEndpoint } from '../utils/normalize-endpoint';
 
 /**
@@ -42,71 +31,11 @@ export function createStreamableHttpController(
   @applyDecorators(...decorators)
   class StreamableHttpController {
     public readonly logger = new Logger(StreamableHttpController.name);
-    public transports: { [sessionId: string]: StreamableHTTPServerTransport } =
-      {};
-    public mcpServers: { [sessionId: string]: McpServer } = {};
-
-    public isStatelessMode: boolean = false;
 
     constructor(
       @Inject('MCP_OPTIONS') public readonly options: McpOptions,
-      @Inject('MCP_MODULE_ID') public readonly mcpModuleId: string,
-      public readonly moduleRef: ModuleRef,
-      public readonly toolRegistry: McpRegistryService,
-    ) {
-      // Determine if we're in stateless mode
-      this.isStatelessMode = !!options.streamableHttp?.statelessMode;
-    }
-
-    /**
-     * Create a new MCP server instance for stateless requests
-     */
-    async createStatelessServer(rawReq: any): Promise<{
-      server: McpServer;
-      transport: StreamableHTTPServerTransport;
-    }> {
-      // Create a new transport for this request
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-        enableJsonResponse:
-          this.options.streamableHttp?.enableJsonResponse || false,
-      });
-
-      // Create a new MCP server instance with dynamic capabilities
-      const capabilities = buildMcpCapabilities(
-        this.mcpModuleId,
-        this.toolRegistry,
-        this.options,
-      );
-      this.logger.debug('Built MCP capabilities:', capabilities);
-
-      const server = new McpServer(
-        { name: this.options.name, version: this.options.version },
-        {
-          capabilities: capabilities,
-          instructions: this.options.instructions || '',
-        },
-      );
-
-      // Connect the transport to the MCP server first
-      await server.connect(transport);
-
-      // Now resolve the request-scoped tool executor service
-      const contextId = ContextIdFactory.getByRequest(rawReq);
-      const executor = await this.moduleRef.resolve(
-        McpExecutorService,
-        contextId,
-        { strict: true },
-      );
-
-      // Register request handlers after connection
-      this.logger.debug(
-        'Registering request handlers for stateless MCP server',
-      );
-      executor.registerRequestHandlers(server, rawReq);
-
-      return { server, transport };
-    }
+      public readonly mcpStreamableHttpService: McpStreamableHttpService,
+    ) {}
 
     /**
      * Main HTTP endpoint for both initialization and subsequent requests
@@ -117,198 +46,8 @@ export function createStreamableHttpController(
       @Req() req: any,
       @Res() res: any,
       @Body() body: unknown,
-    ) {
-      this.logger.debug('Received MCP request:', body);
-
-      // Get the appropriate HTTP adapter for the request/response
-      const adapter = HttpAdapterFactory.getAdapter(req, res);
-      const adaptedReq = adapter.adaptRequest(req);
-      const adaptedRes = adapter.adaptResponse(res);
-
-      try {
-        if (this.isStatelessMode) {
-          return this.handleStatelessRequest(adaptedReq, adaptedRes, body);
-        } else {
-          return this.handleStatefulRequest(adaptedReq, adaptedRes, body);
-        }
-      } catch (error) {
-        this.logger.error('Error handling MCP request:', error);
-        if (!adaptedRes.headersSent) {
-          adaptedRes.status(500).json({
-            jsonrpc: '2.0',
-            error: {
-              code: -32603,
-              message: 'Internal server error',
-            },
-            id: null,
-          });
-        }
-      }
-    }
-
-    /**
-     * Handle requests in stateless mode
-     */
-    public async handleStatelessRequest(
-      req: any,
-      res: HttpResponse,
-      body: unknown,
     ): Promise<void> {
-      this.logger.debug(
-        `Handling stateless MCP request at ${req.url} with body: ${JSON.stringify(
-          body,
-        )}`,
-      );
-
-      let server: McpServer | null = null;
-      let transport: StreamableHTTPServerTransport | null = null;
-
-      try {
-        // Create a new server and transport for each request
-        const stateless = await this.createStatelessServer(req);
-        server = stateless.server;
-        transport = stateless.transport;
-
-        // Handle the request
-        await transport.handleRequest(req.raw, res.raw, body);
-
-        // Clean up when the response closes
-        res.on?.('close', () => {
-          this.logger.debug('Stateless request closed, cleaning up');
-          void transport?.close();
-          void server?.close();
-        });
-      } catch (error) {
-        this.logger.error('Error in stateless request handling:', error);
-        // Clean up on error
-        void transport?.close();
-        void server?.close();
-        throw error;
-      }
-    }
-
-    /**
-     * Handle requests in stateful mode
-     */
-    public async handleStatefulRequest(
-      req: HttpRequest,
-      res: HttpResponse,
-      body: unknown,
-    ): Promise<void> {
-      this.logger.debug(
-        `Handling stateful MCP request at ${req.url} with body: ${JSON.stringify(
-          body,
-        )}`,
-      );
-      // Check for existing session ID
-      const sessionId = req.headers['mcp-session-id'] as string | undefined;
-      let transport: StreamableHTTPServerTransport;
-
-      if (sessionId && this.transports[sessionId]) {
-        // Reuse existing transport
-        transport = this.transports[sessionId];
-      } else if (!sessionId && this.isInitializeRequest(body)) {
-        // New initialization request
-        transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator:
-            this.options.streamableHttp?.sessionIdGenerator ||
-            (() => randomUUID()),
-          enableJsonResponse:
-            this.options.streamableHttp?.enableJsonResponse || false,
-          onsessioninitialized: (sessionId: string) => {
-            this.logger.debug(`Session initialized: ${sessionId}`);
-            this.transports[sessionId] = transport;
-          },
-        });
-
-        // Create a new MCP server for this session with dynamic capabilities
-        const capabilities = buildMcpCapabilities(
-          this.mcpModuleId,
-          this.toolRegistry,
-          this.options,
-        );
-        this.logger.debug('Built MCP capabilities:', capabilities);
-
-        const mcpServer = new McpServer(
-          { name: this.options.name, version: this.options.version },
-          {
-            capabilities,
-            instructions: this.options.instructions || '',
-          },
-        );
-
-        // Connect the transport to the MCP server BEFORE handling the request
-        await mcpServer.connect(transport);
-
-        // Handle the initialization request
-        await transport.handleRequest(req.raw, res.raw, body);
-
-        // Store the transport and server by session ID for future requests
-        if (transport.sessionId) {
-          this.transports[transport.sessionId] = transport;
-          this.mcpServers[transport.sessionId] = mcpServer;
-
-          // Set up cleanup when connection closes
-          transport.onclose = () => {
-            this.cleanupSession(transport.sessionId!);
-          };
-        }
-
-        this.logger.log(
-          `Initialized new session with ID: ${transport.sessionId}`,
-        );
-        return;
-      } else if (sessionId && !this.transports[sessionId]) {
-        // Provided session ID but no matching session exists
-        res.status(404).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Session not found',
-          },
-          id: null,
-        });
-        return;
-      } else {
-        // Invalid request - no session ID or not initialization request
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Bad Request: No valid session ID provided',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      // For subsequent requests to an existing session
-      const mcpServer = this.mcpServers[sessionId];
-      if (!mcpServer) {
-        res.status(404).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Session not found',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      // Resolve the request-scoped tool executor service
-      const contextId = ContextIdFactory.getByRequest(req);
-      const executor = await this.moduleRef.resolve(
-        McpExecutorService,
-        contextId,
-        { strict: true },
-      );
-
-      // Register request handlers with the user context from this specific request
-      executor.registerRequestHandlers(mcpServer, req);
-
-      // Handle the request with existing transport
-      await transport.handleRequest(req.raw, res.raw, body);
+      await this.mcpStreamableHttpService.handlePostRequest(req, res, body);
     }
 
     /**
@@ -316,36 +55,8 @@ export function createStreamableHttpController(
      */
     @Get(`${normalizeEndpoint(`${apiPrefix}/${endpoint}`)}`)
     @UseGuards(...guards)
-    async handleGetRequest(@Req() req: any, @Res() res: any) {
-      // Get the appropriate HTTP adapter for the request/response
-      const adapter = HttpAdapterFactory.getAdapter(req, res);
-      const adaptedReq = adapter.adaptRequest(req);
-      const adaptedRes = adapter.adaptResponse(res);
-
-      if (this.isStatelessMode) {
-        adaptedRes.status(405).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Method not allowed in stateless mode',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      const sessionId = adaptedReq.headers['mcp-session-id'] as
-        | string
-        | undefined;
-
-      if (!sessionId || !this.transports[sessionId]) {
-        adaptedRes.status(400).send('Invalid or missing session ID');
-        return;
-      }
-
-      this.logger.debug(`Establishing SSE stream for session ${sessionId}`);
-      const transport = this.transports[sessionId];
-      await transport.handleRequest(adaptedReq.raw, adaptedRes.raw);
+    async handleGetRequest(@Req() req: any, @Res() res: any): Promise<void> {
+      await this.mcpStreamableHttpService.handleGetRequest(req, res);
     }
 
     /**
@@ -353,65 +64,8 @@ export function createStreamableHttpController(
      */
     @Delete(`${normalizeEndpoint(`${apiPrefix}/${endpoint}`)}`)
     @UseGuards(...guards)
-    async handleDeleteRequest(@Req() req: any, @Res() res: any) {
-      // Get the appropriate HTTP adapter for the request/response
-      const adapter = HttpAdapterFactory.getAdapter(req, res);
-      const adaptedReq = adapter.adaptRequest(req);
-      const adaptedRes = adapter.adaptResponse(res);
-
-      if (this.isStatelessMode) {
-        adaptedRes.status(405).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32000,
-            message: 'Method not allowed in stateless mode',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      const sessionId = adaptedReq.headers['mcp-session-id'] as
-        | string
-        | undefined;
-
-      if (!sessionId || !this.transports[sessionId]) {
-        adaptedRes.status(400).send('Invalid or missing session ID');
-        return;
-      }
-
-      this.logger.debug(`Terminating session ${sessionId}`);
-      const transport = this.transports[sessionId];
-      await transport.handleRequest(adaptedReq.raw, adaptedRes.raw);
-      this.cleanupSession(sessionId);
-    }
-
-    // Helper function to detect initialize requests
-    public isInitializeRequest(body: unknown): boolean {
-      if (Array.isArray(body)) {
-        return body.some(
-          (msg) =>
-            typeof msg === 'object' &&
-            msg !== null &&
-            'method' in msg &&
-            msg.method === 'initialize',
-        );
-      }
-      return (
-        typeof body === 'object' &&
-        body !== null &&
-        'method' in body &&
-        body.method === 'initialize'
-      );
-    }
-
-    // Clean up session resources
-    public cleanupSession(sessionId: string): void {
-      if (sessionId) {
-        this.logger.debug(`Cleaning up session: ${sessionId}`);
-        delete this.transports[sessionId];
-        delete this.mcpServers[sessionId];
-      }
+    async handleDeleteRequest(@Req() req: any, @Res() res: any): Promise<void> {
+      await this.mcpStreamableHttpService.handleDeleteRequest(req, res);
     }
   }
 


### PR DESCRIPTION
Resolves https://github.com/rekog-labs/MCP-Nest/issues/64 without breaking changes. 

As the advanced server shows, you disable all transports:

```
McpModule.forRoot({
  name: 'my-server',
  version: '1.0.0',
  transport: [], // Disable all automatic controller generation
})
```

And then create a custom controller that makes use of McpSseService or McpStreamableHttpService.

This is a first draft. I see opportunities to improve the API further. So right now it is available under `rekog/mcp-nest@1.8.1-alpha.2`