### PR TITLE
refactor streamable http service

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -5,3 +5,5 @@ export * from './services/mcp-registry.service';
 export * from './services/mcp-executor.service';
 export * from './services/mcp-sse.service';
 export * from './services/mcp-streamable-http.service';
+export * from './services/mcp-streamable-http-stateless.service';
+export * from './services/mcp-streamable-http-stateful.service';

--- a/src/mcp/mcp.module.ts
+++ b/src/mcp/mcp.module.ts
@@ -11,6 +11,8 @@ import { McpExecutorService } from './services/mcp-executor.service';
 import { McpRegistryService } from './services/mcp-registry.service';
 import { McpSseService } from './services/mcp-sse.service';
 import { McpStreamableHttpService } from './services/mcp-streamable-http.service';
+import { McpStreamableHttpStatefulService } from './services/mcp-streamable-http-stateful.service';
+import { McpStreamableHttpStatelessService } from './services/mcp-streamable-http-stateless.service';
 import { SsePingService } from './services/sse-ping.service';
 import { createSseController } from './transport/sse.controller.factory';
 import { StdioService } from './transport/stdio.service';
@@ -93,6 +95,8 @@ export class McpModule {
       McpExecutorService,
       SsePingService,
       McpSseService,
+      McpStreamableHttpStatelessService,
+      McpStreamableHttpStatefulService,
       McpStreamableHttpService,
       StdioService,
     ];
@@ -245,6 +249,8 @@ export class McpModule {
       McpExecutorService,
       SsePingService,
       McpSseService,
+      McpStreamableHttpStatelessService,
+      McpStreamableHttpStatefulService,
       McpStreamableHttpService,
       StdioService,
     ];

--- a/src/mcp/services/mcp-streamable-http-stateful.service.ts
+++ b/src/mcp/services/mcp-streamable-http-stateful.service.ts
@@ -1,0 +1,317 @@
+import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { randomUUID } from 'crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+import { HttpAdapterFactory } from '../adapters/http-adapter.factory';
+import { HttpRequest, HttpResponse } from '../interfaces/http-adapter.interface';
+import { McpOptions } from '../interfaces';
+import { McpExecutorService } from './mcp-executor.service';
+import { McpRegistryService } from './mcp-registry.service';
+import { buildMcpCapabilities } from '../utils/capabilities-builder';
+
+/**
+ * Service handling stateful Streamable HTTP MCP traffic. Sessions are
+ * maintained across requests allowing the server to preserve state between
+ * calls.
+ */
+@Injectable()
+export class McpStreamableHttpStatefulService implements OnModuleDestroy {
+  private readonly logger = new Logger(McpStreamableHttpStatefulService.name);
+  private readonly transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
+  private readonly mcpServers: { [sessionId: string]: McpServer } = {};
+  private readonly executors: { [sessionId: string]: McpExecutorService } = {};
+
+  constructor(
+    @Inject('MCP_OPTIONS') private readonly options: McpOptions,
+    @Inject('MCP_MODULE_ID') private readonly mcpModuleId: string,
+    private readonly moduleRef: ModuleRef,
+    private readonly toolRegistry: McpRegistryService,
+  ) {}
+
+  /**
+   * Handle POST requests for stateful sessions.
+   */
+  async handlePostRequest(req: any, res: any, body: unknown): Promise<void> {
+    const adapter = HttpAdapterFactory.getAdapter(req, res);
+    const adaptedReq = adapter.adaptRequest(req);
+    const adaptedRes = adapter.adaptResponse(res);
+    const sessionId = adaptedReq.headers['mcp-session-id'] as string | undefined;
+
+    this.logger.debug(
+      `[${sessionId || 'New'}] Received MCP request: ${JSON.stringify(body)}`,
+    );
+
+    try {
+      await this.handleStatefulRequest(adaptedReq, adaptedRes, body);
+    } catch (error) {
+      this.logger.error(
+        `[${sessionId || 'No-Session'}] Error handling MCP request: ${error}`,
+      );
+      if (!adaptedRes.headersSent) {
+        adaptedRes.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    }
+  }
+
+  /**
+   * Actual stateful request handling logic.
+   */
+  private async handleStatefulRequest(
+    req: HttpRequest,
+    res: HttpResponse,
+    body: unknown,
+  ): Promise<void> {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+
+    this.logger.debug(`[${sessionId || 'New'}] Handling stateful MCP request`);
+
+    // Case 1: New initialization request
+    if (!sessionId && this.isInitializeRequest(body)) {
+      if (Array.isArray(body) && body.length > 1) {
+        res.status(400).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: 'Invalid Request: Only one initialization request is allowed',
+          },
+          id: null,
+        });
+        return;
+      }
+
+      const capabilities = buildMcpCapabilities(
+        this.mcpModuleId,
+        this.toolRegistry,
+        this.options,
+      );
+
+      const mcpServer = new McpServer(
+        { name: this.options.name, version: this.options.version },
+        {
+          capabilities,
+          instructions: this.options.instructions || '',
+        },
+      );
+
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator:
+          this.options.streamableHttp?.sessionIdGenerator || (() => randomUUID()),
+        enableJsonResponse:
+          this.options.streamableHttp?.enableJsonResponse || false,
+        onsessioninitialized: async (sid: string) => {
+          this.logger.debug(`[${sid}] Session initialized, storing references`);
+          this.transports[sid] = transport;
+          this.mcpServers[sid] = mcpServer;
+
+          const contextId = ContextIdFactory.getByRequest(req.raw ?? req);
+          const executor = await this.moduleRef.resolve(
+            McpExecutorService,
+            contextId,
+            { strict: true },
+          );
+          this.executors[sid] = executor;
+
+          executor.registerRequestHandlers(mcpServer, req);
+        },
+        onsessionclosed: async (sid: string) => {
+          this.logger.debug(`[${sid}] Session closed via DELETE`);
+          await this.cleanupSession(sid);
+        },
+      });
+
+      await mcpServer.connect(transport);
+
+      await transport.handleRequest(req.raw ?? req, res.raw, body);
+
+      this.logger.log(`[${transport.sessionId}] New session initialized`);
+      return;
+    }
+
+    // Case 2: Request with session ID
+    if (sessionId) {
+      if (!this.transports[sessionId]) {
+        this.logger.debug(`[${sessionId}] Session not found`);
+        res.status(404).json({
+          jsonrpc: '2.0',
+          error: { code: -32001, message: 'Session not found' },
+          id: null,
+        });
+        return;
+      }
+
+      if (this.isInitializeRequest(body)) {
+        res.status(400).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32600,
+            message: 'Invalid Request: Server already initialized',
+          },
+          id: null,
+        });
+        return;
+      }
+
+      const transport = this.transports[sessionId];
+
+      this.logger.debug(
+        `[${sessionId}] Handling request with existing session`,
+      );
+
+      await transport.handleRequest(req.raw ?? req, res.raw, body);
+      return;
+    }
+
+    // Case 3: No session ID and not initialization
+    res.status(400).json({
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Bad Request: Mcp-Session-Id header is required',
+      },
+      id: null,
+    });
+  }
+
+  /**
+   * Handle GET requests for SSE streams.
+   */
+  async handleGetRequest(req: any, res: any): Promise<void> {
+    const adapter = HttpAdapterFactory.getAdapter(req, res);
+    const adaptedReq = adapter.adaptRequest(req);
+    const adaptedRes = adapter.adaptResponse(res);
+
+    const sessionId = adaptedReq.headers['mcp-session-id'] as string | undefined;
+
+    if (!sessionId) {
+      adaptedRes.status(400).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Bad Request: Mcp-Session-Id header is required',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    if (!this.transports[sessionId]) {
+      this.logger.debug(`[${sessionId}] GET request - session not found`);
+      adaptedRes.status(404).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Session not found' },
+        id: null,
+      });
+      return;
+    }
+
+    this.logger.debug(`[${sessionId}] Establishing SSE stream`);
+    const transport = this.transports[sessionId];
+    await transport.handleRequest(adaptedReq.raw ?? adaptedReq, adaptedRes.raw);
+  }
+
+  /**
+   * Handle DELETE requests for terminating sessions.
+   */
+  async handleDeleteRequest(req: any, res: any): Promise<void> {
+    const adapter = HttpAdapterFactory.getAdapter(req, res);
+    const adaptedReq = adapter.adaptRequest(req);
+    const adaptedRes = adapter.adaptResponse(res);
+
+    const sessionId = adaptedReq.headers['mcp-session-id'] as string | undefined;
+
+    if (!sessionId) {
+      adaptedRes.status(400).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Bad Request: Mcp-Session-Id header is required',
+        },
+        id: null,
+      });
+      return;
+    }
+
+    if (!this.transports[sessionId]) {
+      this.logger.debug(`[${sessionId}] DELETE request - session not found`);
+      adaptedRes.status(404).json({
+        jsonrpc: '2.0',
+        error: { code: -32001, message: 'Session not found' },
+        id: null,
+      });
+      return;
+    }
+
+    this.logger.debug(`[${sessionId}] Processing DELETE request`);
+    const transport = this.transports[sessionId];
+    await transport.handleRequest(adaptedReq.raw ?? adaptedReq, adaptedRes.raw);
+  }
+
+  /**
+   * Detect initialize requests.
+   */
+  private isInitializeRequest(body: unknown): boolean {
+    if (Array.isArray(body)) {
+      return body.some(
+        (msg) =>
+          typeof msg === 'object' &&
+          msg !== null &&
+          'method' in msg &&
+          (msg as any).method === 'initialize',
+      );
+    }
+    return (
+      typeof body === 'object' &&
+      body !== null &&
+      'method' in body &&
+      (body as any).method === 'initialize'
+    );
+  }
+
+  /**
+   * Clean up session resources.
+   */
+  private async cleanupSession(sessionId: string): Promise<void> {
+    if (!sessionId || !this.transports[sessionId]) {
+      return;
+    }
+
+    this.logger.debug(`[${sessionId}] Cleaning up session`);
+
+    try {
+      const transport = this.transports[sessionId];
+      if (transport) {
+        await transport.close();
+      }
+
+      const server = this.mcpServers[sessionId];
+      if (server) {
+        await server.close();
+      }
+
+      delete this.transports[sessionId];
+      delete this.mcpServers[sessionId];
+      delete this.executors[sessionId];
+    } catch (error) {
+      this.logger.error(`[${sessionId}] Error during cleanup:`, error);
+    }
+  }
+
+  /**
+   * Clean up all sessions on module destroy.
+   */
+  async onModuleDestroy(): Promise<void> {
+    this.logger.log('Cleaning up all MCP sessions...');
+    const sessionIds = Object.keys(this.transports);
+
+    await Promise.all(sessionIds.map((sid) => this.cleanupSession(sid)));
+
+    this.logger.log(`Cleaned up ${sessionIds.length} MCP sessions`);
+  }
+}
+

--- a/src/mcp/services/mcp-streamable-http-stateless.service.ts
+++ b/src/mcp/services/mcp-streamable-http-stateless.service.ts
@@ -1,0 +1,136 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { ContextIdFactory, ModuleRef } from '@nestjs/core';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+
+import { HttpAdapterFactory } from '../adapters/http-adapter.factory';
+import { McpOptions } from '../interfaces';
+import { McpExecutorService } from './mcp-executor.service';
+import { McpRegistryService } from './mcp-registry.service';
+import { buildMcpCapabilities } from '../utils/capabilities-builder';
+
+/**
+ * Service handling stateless Streamable HTTP MCP traffic. A new MCP server
+ * instance is created for each request and cleaned up once the response is
+ * sent. No session management is performed.
+ */
+@Injectable()
+export class McpStreamableHttpStatelessService {
+  private readonly logger = new Logger(McpStreamableHttpStatelessService.name);
+
+  constructor(
+    @Inject('MCP_OPTIONS') private readonly options: McpOptions,
+    @Inject('MCP_MODULE_ID') private readonly mcpModuleId: string,
+    private readonly moduleRef: ModuleRef,
+    private readonly toolRegistry: McpRegistryService,
+  ) {}
+
+  /**
+   * Handle POST requests in stateless mode.
+   */
+  async handlePostRequest(req: any, res: any, body: unknown): Promise<void> {
+    const adapter = HttpAdapterFactory.getAdapter(req, res);
+    const adaptedReq = adapter.adaptRequest(req);
+    const adaptedRes = adapter.adaptResponse(res);
+
+    this.logger.debug(
+      `[Stateless] Received MCP request: ${JSON.stringify(body)}`,
+    );
+
+    let server: McpServer | null = null;
+    let transport: StreamableHTTPServerTransport | null = null;
+
+    try {
+      // Create a dedicated server/transport for this request
+      const created = await this.createServer(adaptedReq);
+      server = created.server;
+      transport = created.transport;
+
+      // Handle the request
+      await transport.handleRequest(
+        adaptedReq.raw ?? adaptedReq,
+        adaptedRes.raw,
+        body,
+      );
+
+      // Clean up once the response finishes
+      adaptedRes.raw.on('finish', async () => {
+        this.logger.debug('[Stateless] Response sent, cleaning up');
+        try {
+          if (transport) await transport.close();
+          if (server) await server.close();
+        } catch (error) {
+          this.logger.error('[Stateless] Error during cleanup:', error);
+        }
+      });
+    } catch (error) {
+      this.logger.error(
+        `[Stateless] Error in stateless request handling: ${error}`,
+      );
+
+      // Attempt cleanup on error
+      try {
+        if (transport) await transport.close();
+        if (server) await server.close();
+      } catch (cleanupError) {
+        this.logger.error(
+          '[Stateless] Error cleaning up after failure:',
+          cleanupError,
+        );
+      }
+
+      if (!adaptedRes.headersSent) {
+        adaptedRes.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    }
+  }
+
+  /**
+   * Create a new MCP server and transport for a request.
+   */
+  private async createServer(rawReq: any): Promise<{
+    server: McpServer;
+    transport: StreamableHTTPServerTransport;
+  }> {
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: this.options.streamableHttp?.enableJsonResponse || false,
+    });
+
+    const capabilities = buildMcpCapabilities(
+      this.mcpModuleId,
+      this.toolRegistry,
+      this.options,
+    );
+    this.logger.debug(
+      `[Stateless] Built MCP capabilities: ${JSON.stringify(capabilities)}`,
+    );
+
+    const server = new McpServer(
+      { name: this.options.name, version: this.options.version },
+      {
+        capabilities,
+        instructions: this.options.instructions || '',
+      },
+    );
+
+    // Connect the transport to the server
+    await server.connect(transport);
+
+    // Resolve executor in request scope and register handlers
+    const contextId = ContextIdFactory.getByRequest(rawReq.raw ?? rawReq);
+    const executor = await this.moduleRef.resolve(
+      McpExecutorService,
+      contextId,
+      { strict: true },
+    );
+    executor.registerRequestHandlers(server, rawReq);
+
+    return { server, transport };
+  }
+}
+

--- a/src/mcp/services/mcp-streamable-http.service.ts
+++ b/src/mcp/services/mcp-streamable-http.service.ts
@@ -1,324 +1,44 @@
 import { Inject, Injectable, Logger, OnModuleDestroy } from '@nestjs/common';
-import { ContextIdFactory, ModuleRef } from '@nestjs/core';
-import { randomUUID } from 'crypto';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { HttpAdapterFactory } from '../adapters/http-adapter.factory';
-import {
-  HttpRequest,
-  HttpResponse,
-} from '../interfaces/http-adapter.interface';
-import { McpOptions } from '../interfaces';
-import { McpExecutorService } from './mcp-executor.service';
-import { McpRegistryService } from './mcp-registry.service';
-import { buildMcpCapabilities } from '../utils/capabilities-builder';
 
+import { HttpAdapterFactory } from '../adapters/http-adapter.factory';
+import { McpOptions } from '../interfaces';
+import { McpStreamableHttpStatelessService } from './mcp-streamable-http-stateless.service';
+import { McpStreamableHttpStatefulService } from './mcp-streamable-http-stateful.service';
+
+/**
+ * Facade service that delegates Streamable HTTP requests to either a stateless
+ * or stateful implementation based on configuration. This keeps the
+ * high-level flow simple while the concrete logic lives in dedicated files.
+ */
 @Injectable()
 export class McpStreamableHttpService implements OnModuleDestroy {
   private readonly logger = new Logger(McpStreamableHttpService.name);
-  private readonly transports: {
-    [sessionId: string]: StreamableHTTPServerTransport;
-  } = {};
-  private readonly mcpServers: { [sessionId: string]: McpServer } = {};
-  private readonly executors: { [sessionId: string]: McpExecutorService } = {};
   private readonly isStatelessMode: boolean;
 
   constructor(
-    @Inject('MCP_OPTIONS') private readonly options: McpOptions,
-    @Inject('MCP_MODULE_ID') private readonly mcpModuleId: string,
-    private readonly moduleRef: ModuleRef,
-    private readonly toolRegistry: McpRegistryService,
+    @Inject('MCP_OPTIONS') options: McpOptions,
+    private readonly stateless: McpStreamableHttpStatelessService,
+    private readonly stateful: McpStreamableHttpStatefulService,
   ) {
-    // Determine if we're in stateless mode
     this.isStatelessMode = !!options.streamableHttp?.statelessMode;
   }
 
   /**
-   * Create a new MCP server instance for stateless requests
+   * Handle POST requests by delegating to the appropriate implementation.
    */
-  async createStatelessServer(rawReq: any): Promise<{
-    server: McpServer;
-    transport: StreamableHTTPServerTransport;
-  }> {
-    // Create a new transport for this request (stateless = no session management)
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: undefined,
-      enableJsonResponse:
-        this.options.streamableHttp?.enableJsonResponse || false,
-    });
-
-    // Create a new MCP server instance with dynamic capabilities
-    const capabilities = buildMcpCapabilities(
-      this.mcpModuleId,
-      this.toolRegistry,
-      this.options,
-    );
-    this.logger.debug(
-      `[Stateless] Built MCP capabilities: ${JSON.stringify(capabilities)}`,
-    );
-
-    const server = new McpServer(
-      { name: this.options.name, version: this.options.version },
-      {
-        capabilities: capabilities,
-        instructions: this.options.instructions || '',
-      },
-    );
-
-    // Connect the transport to the MCP server first
-    await server.connect(transport);
-
-    // Now resolve the request-scoped tool executor service
-    const contextId = ContextIdFactory.getByRequest(rawReq);
-    const executor = await this.moduleRef.resolve(
-      McpExecutorService,
-      contextId,
-      { strict: true },
-    );
-
-    // Register request handlers after connection
-    this.logger.debug(
-      '[Stateless] Registering request handlers for stateless MCP server',
-    );
-    executor.registerRequestHandlers(server, rawReq);
-
-    return { server, transport };
+  handlePostRequest(req: any, res: any, body: unknown): Promise<void> {
+    return this.isStatelessMode
+      ? this.stateless.handlePostRequest(req, res, body)
+      : this.stateful.handlePostRequest(req, res, body);
   }
 
   /**
-   * Handle POST requests
-   */
-  async handlePostRequest(req: any, res: any, body: unknown): Promise<void> {
-    // Get the appropriate HTTP adapter for the request/response
-    const adapter = HttpAdapterFactory.getAdapter(req, res);
-    const adaptedReq = adapter.adaptRequest(req);
-    const adaptedRes = adapter.adaptResponse(res);
-    const sessionId = adaptedReq.headers['mcp-session-id'] as
-      | string
-      | undefined;
-
-    this.logger.debug(
-      `[${sessionId || 'No-Session'}] Received MCP request: ${JSON.stringify(body)}`,
-    );
-
-    try {
-      if (this.isStatelessMode) {
-        return this.handleStatelessRequest(adaptedReq, adaptedRes, body);
-      } else {
-        return this.handleStatefulRequest(adaptedReq, adaptedRes, body);
-      }
-    } catch (error) {
-      this.logger.error(
-        `[${sessionId || 'No-Session'}] Error handling MCP request: ${error}`,
-      );
-      if (!adaptedRes.headersSent) {
-        adaptedRes.status(500).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32603,
-            message: 'Internal server error',
-          },
-          id: null,
-        });
-      }
-    }
-  }
-
-  /**
-   * Handle requests in stateless mode
-   */
-  async handleStatelessRequest(
-    req: any,
-    res: HttpResponse,
-    body: unknown,
-  ): Promise<void> {
-    this.logger.debug(
-      `[Stateless] Handling stateless MCP request at ${req.url}`,
-    );
-
-    let server: McpServer | null = null;
-    let transport: StreamableHTTPServerTransport | null = null;
-
-    try {
-      // Create a new server and transport for each request
-      const stateless = await this.createStatelessServer(req);
-      server = stateless.server;
-      transport = stateless.transport;
-
-      // Handle the request
-      await transport.handleRequest(req.raw, res.raw, body);
-
-      // Clean up after response is sent
-      res.raw.on('finish', async () => {
-        this.logger.debug('[Stateless] Response sent, cleaning up');
-        try {
-          if (transport) await transport.close();
-          if (server) await server.close();
-        } catch (error) {
-          this.logger.error('[Stateless] Error cleaning up:', error);
-        }
-      });
-    } catch (error) {
-      this.logger.error(
-        `[Stateless] Error in stateless request handling: ${error}`,
-      );
-      // Clean up on error
-      try {
-        if (transport) await transport.close();
-        if (server) await server.close();
-      } catch (error) {
-        this.logger.error('[Stateless] Error cleaning up on error:', error);
-      }
-      throw error;
-    }
-  }
-
-  /**
-   * Handle requests in stateful mode
-   */
-  async handleStatefulRequest(
-    req: HttpRequest,
-    res: HttpResponse,
-    body: unknown,
-  ): Promise<void> {
-    const sessionId = req.headers['mcp-session-id'] as string | undefined;
-
-    this.logger.debug(`[${sessionId || 'New'}] Handling stateful MCP request`);
-
-    // Case 1: New initialization request
-    if (!sessionId && this.isInitializeRequest(body)) {
-      // Validate it's not a batch with multiple requests
-      if (Array.isArray(body) && body.length > 1) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32600,
-            message:
-              'Invalid Request: Only one initialization request is allowed',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      // Build capabilities
-      const capabilities = buildMcpCapabilities(
-        this.mcpModuleId,
-        this.toolRegistry,
-        this.options,
-      );
-
-      // Create MCP server
-      const mcpServer = new McpServer(
-        { name: this.options.name, version: this.options.version },
-        {
-          capabilities,
-          instructions: this.options.instructions || '',
-        },
-      );
-
-      // Create transport with session management
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator:
-          this.options.streamableHttp?.sessionIdGenerator ||
-          (() => randomUUID()),
-        enableJsonResponse:
-          this.options.streamableHttp?.enableJsonResponse || false,
-        onsessioninitialized: async (sid: string) => {
-          this.logger.debug(`[${sid}] Session initialized, storing references`);
-          // Store all session data
-          this.transports[sid] = transport;
-          this.mcpServers[sid] = mcpServer;
-
-          // Resolve and store the executor for this session
-          const contextId = ContextIdFactory.getByRequest(req);
-          const executor = await this.moduleRef.resolve(
-            McpExecutorService,
-            contextId,
-            { strict: true },
-          );
-          this.executors[sid] = executor;
-
-          // Register request handlers ONCE during initialization
-          executor.registerRequestHandlers(mcpServer, req);
-        },
-        onsessionclosed: async (sid: string) => {
-          this.logger.debug(`[${sid}] Session closed via DELETE`);
-          await this.cleanupSession(sid);
-        },
-      });
-
-      // Connect transport to server
-      await mcpServer.connect(transport);
-
-      // Handle the initialization request
-      await transport.handleRequest(req.raw, res.raw, body);
-
-      this.logger.log(`[${transport.sessionId}] New session initialized`);
-      return;
-    }
-
-    // Case 2: Request with session ID
-    if (sessionId) {
-      // Check if session exists
-      if (!this.transports[sessionId]) {
-        this.logger.debug(`[${sessionId}] Session not found`);
-        res.status(404).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32001,
-            message: 'Session not found',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      // Reject re-initialization attempts
-      if (this.isInitializeRequest(body)) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: {
-            code: -32600,
-            message: 'Invalid Request: Server already initialized',
-          },
-          id: null,
-        });
-        return;
-      }
-
-      // Use existing transport
-      const transport = this.transports[sessionId];
-
-      this.logger.debug(
-        `[${sessionId}] Handling request with existing session`,
-      );
-
-      // Handle the request with existing transport and handlers
-      await transport.handleRequest(req.raw, res.raw, body);
-      return;
-    }
-
-    // Case 3: No session ID and not initialization
-    res.status(400).json({
-      jsonrpc: '2.0',
-      error: {
-        code: -32000,
-        message: 'Bad Request: Mcp-Session-Id header is required',
-      },
-      id: null,
-    });
-  }
-
-  /**
-   * Handle GET requests for SSE streams
+   * Handle GET requests. Only supported in stateful mode.
    */
   async handleGetRequest(req: any, res: any): Promise<void> {
-    const adapter = HttpAdapterFactory.getAdapter(req, res);
-    const adaptedReq = adapter.adaptRequest(req);
-    const adaptedRes = adapter.adaptResponse(res);
-
     if (this.isStatelessMode) {
+      const adapter = HttpAdapterFactory.getAdapter(req, res);
+      const adaptedRes = adapter.adaptResponse(res);
       adaptedRes.status(405).json({
         jsonrpc: '2.0',
         error: {
@@ -330,49 +50,16 @@ export class McpStreamableHttpService implements OnModuleDestroy {
       return;
     }
 
-    const sessionId = adaptedReq.headers['mcp-session-id'] as
-      | string
-      | undefined;
-
-    if (!sessionId) {
-      adaptedRes.status(400).json({
-        jsonrpc: '2.0',
-        error: {
-          code: -32000,
-          message: 'Bad Request: Mcp-Session-Id header is required',
-        },
-        id: null,
-      });
-      return;
-    }
-
-    if (!this.transports[sessionId]) {
-      this.logger.debug(`[${sessionId}] GET request - session not found`);
-      adaptedRes.status(404).json({
-        jsonrpc: '2.0',
-        error: {
-          code: -32001,
-          message: 'Session not found',
-        },
-        id: null,
-      });
-      return;
-    }
-
-    this.logger.debug(`[${sessionId}] Establishing SSE stream`);
-    const transport = this.transports[sessionId];
-    await transport.handleRequest(adaptedReq.raw, adaptedRes.raw);
+    return this.stateful.handleGetRequest(req, res);
   }
 
   /**
-   * Handle DELETE requests for terminating sessions
+   * Handle DELETE requests. Only supported in stateful mode.
    */
   async handleDeleteRequest(req: any, res: any): Promise<void> {
-    const adapter = HttpAdapterFactory.getAdapter(req, res);
-    const adaptedReq = adapter.adaptRequest(req);
-    const adaptedRes = adapter.adaptResponse(res);
-
     if (this.isStatelessMode) {
+      const adapter = HttpAdapterFactory.getAdapter(req, res);
+      const adaptedRes = adapter.adaptResponse(res);
       adaptedRes.status(405).json({
         jsonrpc: '2.0',
         error: {
@@ -384,107 +71,13 @@ export class McpStreamableHttpService implements OnModuleDestroy {
       return;
     }
 
-    const sessionId = adaptedReq.headers['mcp-session-id'] as
-      | string
-      | undefined;
-
-    if (!sessionId) {
-      adaptedRes.status(400).json({
-        jsonrpc: '2.0',
-        error: {
-          code: -32000,
-          message: 'Bad Request: Mcp-Session-Id header is required',
-        },
-        id: null,
-      });
-      return;
-    }
-
-    if (!this.transports[sessionId]) {
-      this.logger.debug(`[${sessionId}] DELETE request - session not found`);
-      adaptedRes.status(404).json({
-        jsonrpc: '2.0',
-        error: {
-          code: -32001,
-          message: 'Session not found',
-        },
-        id: null,
-      });
-      return;
-    }
-
-    this.logger.debug(`[${sessionId}] Processing DELETE request`);
-    const transport = this.transports[sessionId];
-
-    // Let transport handle the DELETE request
-    // The onsessionclosed callback will handle cleanup
-    await transport.handleRequest(adaptedReq.raw, adaptedRes.raw);
+    return this.stateful.handleDeleteRequest(req, res);
   }
 
-  /**
-   * Helper function to detect initialize requests
-   */
-  private isInitializeRequest(body: unknown): boolean {
-    if (Array.isArray(body)) {
-      return body.some(
-        (msg) =>
-          typeof msg === 'object' &&
-          msg !== null &&
-          'method' in msg &&
-          msg.method === 'initialize',
-      );
-    }
-    return (
-      typeof body === 'object' &&
-      body !== null &&
-      'method' in body &&
-      (body as any).method === 'initialize'
-    );
-  }
-
-  /**
-   * Clean up session resources
-   */
-  private async cleanupSession(sessionId: string): Promise<void> {
-    if (!sessionId || !this.transports[sessionId]) {
-      return;
-    }
-
-    this.logger.debug(`[${sessionId}] Cleaning up session`);
-
-    try {
-      // Close transport if still open
-      const transport = this.transports[sessionId];
-      if (transport) {
-        await transport.close();
-      }
-
-      // Close MCP server
-      const server = this.mcpServers[sessionId];
-      if (server) {
-        await server.close();
-      }
-
-      // Clean up all references
-      delete this.transports[sessionId];
-      delete this.mcpServers[sessionId];
-      delete this.executors[sessionId];
-    } catch (error) {
-      this.logger.error(`[${sessionId}] Error during cleanup:`, error);
-    }
-  }
-
-  /**
-   * Clean up all sessions on module destroy
-   */
   async onModuleDestroy(): Promise<void> {
-    this.logger.log('Cleaning up all MCP sessions...');
-    const sessionIds = Object.keys(this.transports);
-
-    await Promise.all(
-      sessionIds.map((sessionId) => this.cleanupSession(sessionId)),
-    );
-
-    this.logger.log(`Cleaned up ${sessionIds.length} MCP sessions`);
+    if (!this.isStatelessMode) {
+      await this.stateful.onModuleDestroy();
+    }
   }
 }
+


### PR DESCRIPTION
## Summary
- split Streamable HTTP service into dedicated stateless and stateful implementations
- add facade to delegate requests based on configuration
- register new services in module and export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b01c331428832aa7c25503813d6847