### PR TITLE
expose _meta field for tools

### DIFF
--- a/src/mcp/decorators/tool.decorator.ts
+++ b/src/mcp/decorators/tool.decorator.ts
@@ -9,6 +9,7 @@ export interface ToolMetadata {
   parameters?: z.ZodTypeAny;
   outputSchema?: z.ZodTypeAny;
   annotations?: SdkToolAnnotations;
+  _meta?: Record<string, any>;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
@@ -20,6 +21,7 @@ export interface ToolOptions {
   parameters?: z.ZodTypeAny;
   outputSchema?: z.ZodTypeAny;
   annotations?: ToolAnnotations;
+  _meta?: Record<string, any>;
 }
 
 /**

--- a/src/mcp/services/handlers/mcp-tools.handler.ts
+++ b/src/mcp/services/handlers/mcp-tools.handler.ts
@@ -70,6 +70,7 @@ export class McpToolsHandler extends McpHandlerBase {
           name: tool.metadata.name,
           description: tool.metadata.description,
           annotations: tool.metadata.annotations,
+          _meta: tool.metadata._meta,
         };
 
         // Add input schema if defined


### PR DESCRIPTION
`_meta` is being used by OpenAI's AppsSDK for component display

https://developers.openai.com/apps-sdk/build/examples

I'm having trouble figuring out why the `stdio` test is failing. Any help would be appreciated here.