### PR TITLE
feat(mcp): Introduce pluggable validation adapter - Fixes: #146

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -2,281 +2,207 @@
 
 Tools are functions that AI agents can execute to perform actions or computations. In mcp-nest, tools are defined using the `@Tool()` decorator on service methods.
 
-## Basic Tool
+This guide covers two primary ways to define tool parameters:
+1. **`class-validator` (Recommended)**: The standard, idiomatic way in the NestJS ecosystem.
+2. **`zod`**: A powerful alternative for schema-first development.
+
+---
+
+## Defining Parameters with `class-validator` (Recommended)
+
+This is the recommended approach as it integrates seamlessly with NestJS's built-in validation and Swagger documentation pipelines.
+
+### 1. Create a DTO
+
+First, define a Data Transfer Object (DTO) class using `class-validator` for validation rules and `@nestjs/swagger`'s `@ApiProperty` for schema metadata.
 
 ```typescript
-import type { Request } from 'express';
+// greeting.dto.ts
+import { IsString, IsIn } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class GreetingDto {
+  @ApiProperty({ description: 'The name of the person to greet' })
+  @IsString()
+  name: string;
+
+  @ApiProperty({
+    description: 'Language code (e.g., "en", "es", "fr")',
+    enum: ['en', 'es', 'fr'],
+  })
+  @IsIn(['en', 'es', 'fr'])
+  language: string;
+}
+```
+
+### 2. Create the Tool
+
+Use the DTO class as the `parameters` type in your `@Tool` decorator. The method argument will be an instance of your DTO class.
+
+```typescript
+// greeting.tool.ts
 import { Injectable } from '@nestjs/common';
 import { Tool, Context } from '@rekog/mcp-nest';
-import { z } from 'zod';
+import { GreetingDto } from './greeting.dto';
 
 @Injectable()
 export class GreetingTool {
   @Tool({
     name: 'greet-user',
     description: "Returns a personalized greeting in the user's preferred language",
-    parameters: z.object({
-      name: z.string().describe('The name of the person to greet'),
-      language: z.string().describe('Language code (e.g., "en", "es", "fr")'),
-    }),
+    parameters: GreetingDto, // Use the DTO class here
   })
-  async sayHello({ name, language }, context: Context, request: Request) {
+  async sayHello({ name, language }: GreetingDto, context: Context) {
     const greetings = {
       en: 'Hey',
       es: 'Qué tal',
       fr: 'Salut',
     };
-
     const greeting = greetings[language] || greetings.en;
     return `${greeting}, ${name}!`;
   }
 }
 ```
 
+### 3. Configure the Module
+
+To use `class-validator`, you must explicitly provide the `ClassValidatorAdapter` when setting up the `McpModule`.
+
+```typescript
+// app.module.ts
+import { Module } from '@nestjs/common';
+import { McpModule, ClassValidatorAdapter } from '@rekog/mcp-nest';
+import { GreetingTool } from './greeting.tool';
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'my-mcp-server',
+      version: '1.0.0',
+      validationAdapter: new ClassValidatorAdapter(), // Provide the adapter
+    }),
+  ],
+  providers: [GreetingTool],
+})
+export class AppModule {}
+```
+**Note:** You also need to have `class-validator`, `class-transformer`, and `@nestjs/swagger` installed.
+
+---
+
+## Defining Parameters with `zod`
+
+If you prefer Zod's schema-first approach, it works out-of-the-box without any extra configuration.
+
+### 1. Create the Tool
+
+Define a Zod schema and pass it to the `parameters` property in the `@Tool` decorator.
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { Tool, Context } from '@rekog/mcp-nest';
+import { z } from 'zod';
+
+const GreetingSchema = z.object({
+  name: z.string().describe('The name of the person to greet'),
+  language: z.enum(['en', 'es', 'fr']).describe('Language code'),
+});
+
+@Injectable()
+export class GreetingToolWithZod {
+  @Tool({
+    name: 'greet-user-zod',
+    description: "Returns a personalized greeting using a Zod schema",
+    parameters: GreetingSchema, // Use the Zod schema here
+  })
+  async sayHello({ name, language }: z.infer<typeof GreetingSchema>) {
+    // ... implementation ...
+  }
+}
+```
+
+### 2. Configure the Module
+
+The `ZodValidationAdapter` is used by default, so no special configuration is needed.
+
+```typescript
+// app.module.ts
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'my-mcp-server',
+      version: '1.0.0',
+      // No validationAdapter needed, defaults to Zod
+    }),
+  ],
+  providers: [GreetingToolWithZod],
+})
+export class AppModule {}
+```
+
+---
+
+## Advanced Tool Features
+
 ### Understanding Tool Method Parameters
 
 Every tool method receives exactly **three parameters** in this order:
 
-1. **`args`** (first parameter): The validated input parameters as defined by the `parameters` Zod schema in the `@Tool` decorator.
+1.  **`args`**: The validated input parameters, typed as your DTO class or inferred from your Zod schema.
+2.  **`context: Context`**: The MCP execution context, providing access to `reportProgress()`, `mcpServer`, and more.
+3.  **`request: Request`**: The original HTTP request object (Express/Fastify), which is `undefined` when using the STDIO transport.
 
-2. **`context: Context`** (second parameter): The MCP execution context providing access to:
-   - `reportProgress()` - Method to report progress updates to the client
-   - `mcpServer` - Access to the underlying MCP server instance for advanced operations like elicitation
-   - `mcpRequest` - The MCP request object
-   - Logging capabilities and other contextual information
-
-3. **`request: Request`** (third parameter): The original HTTP request object (Express/Fastify), providing access to headers, query parameters, authentication data, and other HTTP-specific information. This parameter is `undefined` when using STDIO transport.
-
-### Tool Decorator Properties
-
-The `@Tool()` decorator accepts a configuration object with the following properties:
-
-- **`name`** (required): Unique identifier for the tool within your MCP server
-- **`description`** (required): Human-readable description explaining what the tool does
-- **`parameters`** (required): Zod schema defining the expected input parameters and their validation rules
-- **`outputSchema`** (optional): Zod schema for validating and structuring the tool's return value
-- **`annotations`** (optional): Metadata hints for AI agents, including:
-  - `readOnlyHint`: Indicates if the tool only reads data without side effects
-  - `destructiveHint`: Warns if the tool modifies or deletes data
-  - `idempotentHint`: Indicates if repeated calls with same input produce same output
-  - `openWorldHint`: Suggests if the tool's behavior is predictable or may vary
-
-For detailed type definitions, refer to the `Context` interface and `ToolOptions` type in the `@rekog/mcp-nest` package.
-
-## Tool with Progress Reporting
+### Tool with Progress Reporting
 
 ```typescript
 @Tool({
   name: 'process-data',
   description: 'Processes data with progress updates',
-  parameters: z.object({
-    data: z.string(),
-  }),
+  parameters: z.object({ data: z.string() }), // Zod or a DTO can be used
 })
 async processData({ data }, context: Context) {
-  const totalSteps = 5;
-
-  for (let i = 0; i < totalSteps; i++) {
+  for (let i = 0; i <= 5; i++) {
     await new Promise(resolve => setTimeout(resolve, 100));
-
-    // Report progress to the client
-    await context.reportProgress({
-      progress: (i + 1) * 20,
-      total: 100,
-    });
+    await context.reportProgress({ progress: i * 20, total: 100 });
   }
-
   return `Processed: ${data}`;
 }
 ```
 
-## Tool with Output Schema
+### Tool with Output Schema
 
-Tools can define structured output schemas for type safety:
+You can also use a DTO or a Zod schema for `outputSchema` to validate the tool's return value.
 
 ```typescript
+// Using a DTO for the output
 @Tool({
   name: 'greet-user-structured',
-  description: 'Returns a structured greeting with metadata',
-  parameters: z.object({
-    name: z.string(),
-    language: z.string(),
-  }),
-  outputSchema: z.object({
-    greeting: z.string(),
-    language: z.string(),
-    languageName: z.string(),
-  }),
+  description: 'Returns a structured greeting',
+  parameters: GreetingDto,
+  outputSchema: GreetingResultDto, // DTO class for the output
 })
-async sayHelloStructured({ name, language }) {
-  return {
-    greeting: `Hey, ${name}!`,
-    language,
-    languageName: 'English',
-  };
+async sayHelloStructured({ name, language }: GreetingDto): Promise<GreetingResultDto> {
+  // ...
+  return { greeting: '...', language, languageName: '...' };
 }
 ```
 
-## Interactive Tool with Elicitation
+### Interactive Tool with Elicitation
 
-Tools can request additional input from users:
+Elicitation allows a tool to request more information from the user during its execution.
 
 ```typescript
-@Tool({
-  name: 'greet-user-interactive',
-  description: 'Interactive greeting with language selection',
-  parameters: z.object({
-    name: z.string(),
-  }),
-})
-async sayHelloInteractive({ name }, context: Context) {
+@Tool({ name: 'interactive-tool', parameters: z.object({ name: z.string() }) })
+async interactiveTool({ name }, context: Context) {
   const response = await context.mcpServer.server.elicitInput({
-    message: 'Please select your preferred language',
+    message: 'Please provide your age.',
     requestedSchema: {
       type: 'object',
-      properties: {
-        language: {
-          type: 'string',
-          enum: ['en', 'es', 'fr', 'de'],
-          description: 'Your preferred language',
-        },
-      },
+      properties: { age: { type: 'number' } },
     },
   });
 
-  const selectedLanguage = response.action === 'accept'
-    ? response.content.language
-    : 'en';
-
-  return `Hello, ${name}! (in ${selectedLanguage})`;
+  const age = response.action === 'accept' ? response.content.age : 'unknown';
+  return `Hello, ${name}! Your age is ${age}.`;
 }
 ```
-
-## Testing Your Tools
-
-### 1. Start the Server
-
-Run the playground server:
-
-```bash
-npx ts-node-dev --respawn playground/servers/server-stateful.ts
-```
-
-### 2. List Available Tools
-
-```bash
-npx @modelcontextprotocol/inspector@0.16.2 --cli http://localhost:3030/mcp --transport http --method tools/list
-```
-
-Expected output:
-
-```json
-{
-  "tools": [
-    {
-      "name": "greet-user",
-      "description": "Returns a personalized greeting in the user's preferred language",
-      "inputSchema": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string",
-            "description": "The name of the person to greet"
-          },
-          "language": {
-            "type": "string",
-            "description": "Language code (e.g., \"en\", \"es\", \"fr\", \"de\")"
-          }
-        },
-        "required": ["name", "language"]
-      }
-    }
-  ]
-}
-```
-
-### 3. Call a Tool
-
-**Basic tool call:**
-
-```bash
-npx @modelcontextprotocol/inspector@0.16.2 --cli http://localhost:3030/mcp --transport http --method tools/call --tool-name greet-user --tool-arg name=Alice --tool-arg language=es
-```
-
-Expected output:
-
-```json
-{
-  "content": [
-    {
-      "type": "text",
-      "text": "\"Qué tal, Alice!\""
-    }
-  ]
-}
-```
-
-**Interactive tool call:**
-
-Interactive tool calls, use elicitation to get additional input from users. The **MCP Inspector CLI currently doesn't support elicitation**, but as soon as this [GitHub issue](https://github.com/modelcontextprotocol/inspector/issues/524) is resolved, you can test it with the command below. **In the meantime, you can test it using the MCP Inspector UI.**
-
-```bash
-npx @modelcontextprotocol/inspector@0.16.2 --cli http://localhost:3030/mcp --transport http --method tools/call --tool-name greet-user-interactive --tool-arg name=Bob
-```
-
-Elicited input:
-
-```text
-language: en
-```
-
-Expected output:
-
-```json
-{
-  "content": [
-    {
-      "type": "text",
-      "text": "Hey, Bob!"
-    }
-  ]
-}
-```
-
-**Structured tool call (with output schema):**
-
-```bash
-npx @modelcontextprotocol/inspector@0.16.2 --cli http://localhost:3030/mcp --transport http --method tools/call --tool-name greet-user-structured --tool-arg name=Charlie --tool-arg language=fr
-```
-
-Expected output:
-
-```json
-{
-  "content": [
-    {
-      "type": "text",
-      "text": "{\n  \"greeting\": \"Salut, Charlie!\",\n  \"language\": \"fr\",\n  \"languageName\": \"French\"\n}"
-    }
-  ],
-  "structuredContent": {
-    "greeting": "Salut, Charlie!",
-    "language": "fr",
-    "languageName": "French"
-  }
-}
-```
-
-### 4. Interactive Testing
-
-For interactive testing with progress updates, use the MCP Inspector UI:
-
-```bash
-npx @modelcontextprotocol/inspector@0.16.2
-```
-
-Connect to `http://localhost:3030/mcp` to test your tools interactively and see progress reporting in real-time.
-
-## Example Location
-
-See the complete example at: `playground/resources/greeting.tool.ts`

--- a/docs/validation-adapters.md
+++ b/docs/validation-adapters.md
@@ -1,0 +1,132 @@
+# Advanced: Custom Validation Adapters
+
+The `@rekog/mcp-nest` module uses a flexible adapter-based system for handling parameter and output validation. This allows you to use your preferred validation library. We provide built-in adapters for **Zod** (the default) and **`class-validator`**, but you can easily create your own.
+
+This guide will walk you through the process of creating a custom validation adapter for the `joi` library.
+
+---
+
+## The `IValidationAdapter` Interface
+
+Any custom adapter must implement the `IValidationAdapter` interface. This ensures that the module can correctly validate data and generate JSON schemas for the capabilities document.
+
+```typescript
+// src/mcp/interfaces/validation-adapter.interface.ts
+
+export interface IValidationAdapter {
+  /**
+   * Validates data against a schema.
+   * @returns A promise that resolves to a success or error object.
+   */
+  validate(
+    schema: any,
+    data: any,
+  ): Promise<{ success: true; data: any } | { success: false; error: any }>;
+
+  /**
+   * Converts a schema into a JSON Schema representation.
+   * @returns A promise that resolves to the JSON Schema object.
+   */
+  toJsonSchema(schema: any): Promise<any>;
+}
+```
+
+---
+
+## Example: Creating a `JoiValidationAdapter`
+
+Let's create an adapter for the popular `joi` validation library.
+
+### 1. Install Dependencies
+
+You'll need `joi` and a library to handle the conversion to JSON Schema, such as `joi-to-json-schema`.
+
+```bash
+npm install joi joi-to-json-schema
+```
+
+### 2. Implement the Adapter
+
+Create a new class that implements `IValidationAdapter`.
+
+```typescript
+// joi-validation.adapter.ts
+import { IValidationAdapter } from '@rekog/mcp-nest';
+import * as Joi from 'joi';
+import * as joiToJson from 'joi-to-json-schema';
+
+export class JoiValidationAdapter implements IValidationAdapter {
+  async validate(
+    schema: Joi.Schema,
+    data: any,
+  ): Promise<{ success: true; data: any } | { success: false; error: any }> {
+    const { error, value } = schema.validate(data, {
+      abortEarly: false, // Report all errors
+    });
+
+    if (error) {
+      return { success: false, error: error.details };
+    }
+    return { success: true, data: value };
+  }
+
+  async toJsonSchema(schema: Joi.Schema): Promise<any> {
+    // The 'joi-to-json-schema' library converts a Joi schema to JSON Schema.
+    // Most validation libraries have a similar community package available.
+    const jsonSchema = joiToJson.convert(schema);
+    return jsonSchema;
+  }
+}
+```
+
+### 3. Use the Custom Adapter
+
+Now, simply pass an instance of your new adapter when you configure the `McpModule`.
+
+```typescript
+// app.module.ts
+import { Module } from '@nestjs/common';
+import { McpModule } from '@rekog/mcp-nest';
+import { MyToolProvider } from './my-tool.provider';
+import { JoiValidationAdapter } from './joi-validation.adapter'; // Import your adapter
+
+@Module({
+  imports: [
+    McpModule.forRoot({
+      name: 'my-joi-server',
+      version: '1.0.0',
+      validationAdapter: new JoiValidationAdapter(), // Provide an instance
+    }),
+  ],
+  providers: [MyToolProvider],
+})
+export class AppModule {}
+```
+
+### 4. Define a Tool with a Joi Schema
+
+You can now use Joi schemas directly in your `@Tool` decorators.
+
+```typescript
+import { Injectable } from '@nestjs/common';
+import { Tool } from '@rekog/mcp-nest';
+import * as Joi from 'joi';
+
+const joiSchema = Joi.object({
+  name: Joi.string().required().description('The name to greet'),
+});
+
+@Injectable()
+export class MyToolProvider {
+  @Tool({
+    name: 'joi-tool',
+    description: 'A tool validated with Joi',
+    parameters: joiSchema,
+  })
+  myTool(args: { name: string }) {
+    return `Hello from Joi, ${args.name}!`;
+  }
+}
+```
+
+By following this pattern, you can integrate any validation library of your choice into `@rekog/mcp-nest`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@nestjs/core": "^11.1.1",
         "@nestjs/platform-express": "^11.1.1",
         "@nestjs/platform-fastify": "^11.1.6",
+        "@nestjs/swagger": "^11.1.1",
         "@nestjs/testing": "^11.1.1",
         "@nestjs/typeorm": "^11.0.0",
         "@types/cookie-parser": "^1.4.9",
@@ -36,6 +37,8 @@
         "@types/passport-github": "^1.1.12",
         "@types/passport-google-oauth20": "^2.0.16",
         "@types/supertest": "^6.0.3",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.2.3",
@@ -55,7 +58,10 @@
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-fastify": "^11.1.5",
+        "@nestjs/swagger": "*",
         "@nestjs/typeorm": ">=9.0.0",
+        "class-transformer": "*",
+        "class-validator": "*",
         "express": ">=4.0.0",
         "reflect-metadata": ">=0.1.14",
         "typeorm": ">=0.3.25",
@@ -66,7 +72,16 @@
         "@nestjs/platform-fastify": {
           "optional": true
         },
+        "@nestjs/swagger": {
+          "optional": true
+        },
         "@nestjs/typeorm": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
           "optional": true
         },
         "typeorm": {
@@ -1618,6 +1633,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.2.tgz",
@@ -2034,6 +2056,27 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/passport": {
@@ -2507,6 +2550,71 @@
         }
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.1.tgz",
+      "integrity": "sha512-1MS7xf0pzc1mofG53xrrtrurnziafPUHkqzRm4YUVPA/egeiMaSerQBD/feiAeQ2BnX0WiLsTX4HQFO0icvOjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.29.4"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/@nestjs/swagger/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.1.tgz",
@@ -2646,6 +2754,14 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
@@ -3103,6 +3219,13 @@
         "@types/methods": "^1.1.4",
         "@types/superagent": "^8.1.0"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.8",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.8.tgz",
+      "integrity": "sha512-/NAHBJ0RwpsbLzzbLoLm/GnvCGB+A0/p5S61RUIsh7j3MP2dMkdUbWNdFqnluLlUheAs1CR2GlX2R7uzb7Tc0w==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -4207,6 +4330,25 @@
       "integrity": "sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.2.tgz",
+      "integrity": "sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.11.8",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.9.0"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -7252,6 +7394,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.26",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.26.tgz",
+      "integrity": "sha512-MagMOuqEXB2Pa90cWE+BoCmcKJx+de5uBIicaUkQ+uiEslZ0OBMNOkSZT/36syXNHu68UeayTxPm3DYM2IHoLQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/light-my-request": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
@@ -9309,6 +9458,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.29.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.29.4.tgz",
+      "integrity": "sha512-gJFDz/gyLOCQtWwAgqs6Rk78z9ONnqTnlW11gimG9nLap8drKa3AJBKpzIQMIjl5PD2Ix+Tn+mc/tfoT2tgsng==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.3.tgz",
@@ -10116,6 +10275,16 @@
       },
       "engines": {
         "node": ">=10.12.0"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.15.23",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.23.tgz",
+      "integrity": "sha512-4yoz1kEWqUjzi5zsPbAS/903QXSYp0UOtHsPpp7p9rHAw/W+dkInskAE386Fat3oKRROwO98d9ZB0G4cObgUyw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-fastify": "^11.1.5",
+    "@nestjs/swagger": "*",
     "@nestjs/typeorm": ">=9.0.0",
+    "class-transformer": "*",
+    "class-validator": "*",
     "express": ">=4.0.0",
     "reflect-metadata": ">=0.1.14",
     "typeorm": ">=0.3.25",
@@ -47,7 +50,16 @@
     "@nestjs/platform-fastify": {
       "optional": true
     },
+    "@nestjs/swagger": {
+      "optional": true
+    },
     "@nestjs/typeorm": {
+      "optional": true
+    },
+    "class-transformer": {
+      "optional": true
+    },
+    "class-validator": {
       "optional": true
     },
     "typeorm": {
@@ -62,8 +74,11 @@
     "@nestjs/core": "^11.1.1",
     "@nestjs/platform-express": "^11.1.1",
     "@nestjs/platform-fastify": "^11.1.6",
+    "@nestjs/swagger": "^11.1.1",
     "@nestjs/testing": "^11.1.1",
     "@nestjs/typeorm": "^11.0.0",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.2",
     "@types/jest": "^29.5.14",

--- a/src/mcp/adapters/class-validator-validation.adapter.spec.ts
+++ b/src/mcp/adapters/class-validator-validation.adapter.spec.ts
@@ -1,0 +1,65 @@
+import { IsString, IsNumber, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { ClassValidatorAdapter } from './class-validator-validation.adapter';
+
+class TestDto {
+  @ApiProperty({ description: 'The name of the user' })
+  @IsString()
+  name: string;
+
+  @ApiProperty({ required: false })
+  @IsNumber()
+  @IsOptional()
+  age?: number;
+}
+
+describe('ClassValidatorAdapter', () => {
+  let adapter: ClassValidatorAdapter;
+
+  beforeEach(() => {
+    adapter = new ClassValidatorAdapter();
+  });
+
+  describe('validate', () => {
+    it('should return success for valid data', async () => {
+      const result = await adapter.validate(TestDto, { name: 'test' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toBeInstanceOf(TestDto);
+        expect(result.data.name).toEqual('test');
+      }
+    });
+
+    it('should return error for invalid data', async () => {
+      const result = await adapter.validate(TestDto, { age: 'not-a-number' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ path: 'name' }),
+            expect.objectContaining({ path: 'age' }),
+          ]),
+        );
+      }
+    });
+  });
+
+  describe('toJsonSchema', () => {
+    it('should convert a class to a JSON schema', async () => {
+      const jsonSchema = await adapter.toJsonSchema(TestDto);
+      expect(jsonSchema).toEqual({
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'The name of the user',
+          },
+          age: {
+            type: 'number',
+          },
+        },
+        required: ['name'],
+      });
+    });
+  });
+});

--- a/src/mcp/adapters/class-validator-validation.adapter.ts
+++ b/src/mcp/adapters/class-validator-validation.adapter.ts
@@ -1,0 +1,55 @@
+import { IValidationAdapter } from '../interfaces/validation-adapter.interface';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { Module, Type } from '@nestjs/common';
+import { NestApplication, NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+@Module({})
+class DummyModule {}
+
+export class ClassValidatorAdapter implements IValidationAdapter {
+  private app: NestApplication;
+
+  async validate(
+    schema: Type<any>,
+    data: any,
+  ): Promise<{ success: true; data: any } | { success: false; error: any }> {
+    const instance = plainToInstance(schema, data);
+    const errors = await validate(instance);
+
+    if (errors.length > 0) {
+      return { success: false, error: this.formatErrors(errors) };
+    }
+    return { success: true, data: instance };
+  }
+
+  async toJsonSchema(schema: Type<any>): Promise<any> {
+    if (!this.app) {
+      this.app = await NestFactory.create(DummyModule, { logger: false });
+      this.app.useLogger(false);
+    }
+
+    const config = new DocumentBuilder().build();
+    const document = SwaggerModule.createDocument(this.app, config, {
+      extraModels: [schema],
+    });
+
+    const jsonSchema = document.components?.schemas?.[schema.name];
+
+    if (jsonSchema && 'title' in jsonSchema) {
+      delete jsonSchema.title;
+    }
+
+    return jsonSchema;
+  }
+
+  private formatErrors(errors: any[]) {
+    return errors.map((err) => ({
+      path: err.property,
+      message: err.constraints
+        ? Object.values(err.constraints).join(', ')
+        : 'Validation failed',
+    }));
+  }
+}

--- a/src/mcp/adapters/index.ts
+++ b/src/mcp/adapters/index.ts
@@ -1,3 +1,6 @@
 export * from './express-http.adapter';
 export * from './fastify-http.adapter';
 export * from './http-adapter.factory';
+export * from './class-validator-validation.adapter';
+export * from './zod-validation.adapter';
+

--- a/src/mcp/adapters/zod-validation.adapter.spec.ts
+++ b/src/mcp/adapters/zod-validation.adapter.spec.ts
@@ -1,0 +1,55 @@
+import { z } from 'zod';
+import { ZodValidationAdapter } from './zod-validation.adapter';
+
+describe('ZodValidationAdapter', () => {
+  let adapter: ZodValidationAdapter;
+
+  beforeEach(() => {
+    adapter = new ZodValidationAdapter();
+  });
+
+  describe('validate', () => {
+    const schema = z.object({
+      name: z.string(),
+      age: z.number().optional(),
+    });
+
+    it('should return success for valid data', async () => {
+      const result = await adapter.validate(schema, { name: 'test' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ name: 'test' });
+      }
+    });
+
+    it('should return error for invalid data', async () => {
+      const result = await adapter.validate(schema, { age: 25 });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.fieldErrors.name).toBeDefined();
+      }
+    });
+  });
+
+  describe('toJsonSchema', () => {
+    it('should convert a Zod schema to a JSON schema', async () => {
+      const schema = z.object({
+        name: z.string().describe('The name of the user'),
+      });
+
+      const jsonSchema = await adapter.toJsonSchema(schema);
+      expect(jsonSchema).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+            description: 'The name of the user',
+          },
+        },
+        required: ['name'],
+      });
+    });
+  });
+});

--- a/src/mcp/adapters/zod-validation.adapter.ts
+++ b/src/mcp/adapters/zod-validation.adapter.ts
@@ -1,0 +1,21 @@
+
+import { IValidationAdapter } from '../interfaces/validation-adapter.interface';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+export class ZodValidationAdapter implements IValidationAdapter {
+  async validate(
+    schema: z.ZodTypeAny,
+    data: any,
+  ): Promise<{ success: true; data: any } | { success: false; error: any }> {
+    const result = await schema.safeParseAsync(data);
+    if (result.success) {
+      return { success: true, data: result.data };
+    }
+    return { success: false, error: result.error.flatten() };
+  }
+
+  async toJsonSchema(schema: z.ZodTypeAny): Promise<any> {
+    return zodToJsonSchema(schema);
+  }
+}

--- a/src/mcp/decorators/constants.ts
+++ b/src/mcp/decorators/constants.ts
@@ -2,3 +2,4 @@ export const MCP_TOOL_METADATA_KEY = 'mcp:tool';
 export const MCP_RESOURCE_METADATA_KEY = 'mcp:resource';
 export const MCP_RESOURCE_TEMPLATE_METADATA_KEY = 'mcp:resource-template';
 export const MCP_PROMPT_METADATA_KEY = 'mcp:prompt';
+export const MCP_VALIDATION_ADAPTER = 'mcp:validation-adapter';

--- a/src/mcp/decorators/prompt.decorator.ts
+++ b/src/mcp/decorators/prompt.decorator.ts
@@ -1,23 +1,16 @@
 import { SetMetadata } from '@nestjs/common';
 import { MCP_PROMPT_METADATA_KEY } from './constants';
-import { ZodType, ZodTypeDef, ZodOptional, ZodObject } from 'zod';
-
-type PromptArgsRawShape = {
-  [k: string]:
-    | ZodType<string, ZodTypeDef, string>
-    | ZodOptional<ZodType<string, ZodTypeDef, string>>;
-};
 
 export interface PromptMetadata {
   name: string;
   description: string;
-  parameters?: ZodObject<PromptArgsRawShape>;
+  parameters?: any;
 }
 
 export interface PromptOptions {
   name?: string;
   description: string;
-  parameters?: ZodObject<PromptArgsRawShape>;
+  parameters?: any;
 }
 
 export const Prompt = (options: PromptOptions) => {

--- a/src/mcp/decorators/tool.decorator.ts
+++ b/src/mcp/decorators/tool.decorator.ts
@@ -1,13 +1,12 @@
 import { SetMetadata } from '@nestjs/common';
 import { MCP_TOOL_METADATA_KEY } from './constants';
-import { z } from 'zod';
 import { ToolAnnotations as SdkToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 
 export interface ToolMetadata {
   name: string;
   description: string;
-  parameters?: z.ZodTypeAny;
-  outputSchema?: z.ZodTypeAny;
+  parameters?: any;
+  outputSchema?: any;
   annotations?: SdkToolAnnotations;
   _meta?: Record<string, any>;
 }
@@ -18,8 +17,8 @@ export interface ToolAnnotations extends SdkToolAnnotations {}
 export interface ToolOptions {
   name?: string;
   description?: string;
-  parameters?: z.ZodTypeAny;
-  outputSchema?: z.ZodTypeAny;
+  parameters?: any;
+  outputSchema?: any;
   annotations?: ToolAnnotations;
   _meta?: Record<string, any>;
 }
@@ -29,14 +28,10 @@ export interface ToolOptions {
  * @param {Object} options - The options for the decorator
  * @param {string} options.name - The name of the tool
  * @param {string} options.description - The description of the tool
- * @param {z.ZodTypeAny} [options.parameters] - The parameters of the tool
- * @param {z.ZodTypeAny} [options.outputSchema] - The output schema of the tool
+ * @param {any} [options.parameters] - The parameters of the tool (Zod schema or class-validator class)
+ * @param {any} [options.outputSchema] - The output schema of the tool (Zod schema or class-validator class)
  * @returns {MethodDecorator} - The decorator
  */
 export const Tool = (options: ToolOptions) => {
-  if (options.parameters === undefined) {
-    options.parameters = z.object({});
-  }
-
   return SetMetadata(MCP_TOOL_METADATA_KEY, options);
 };

--- a/src/mcp/interfaces/index.ts
+++ b/src/mcp/interfaces/index.ts
@@ -1,3 +1,4 @@
 export * from './mcp-options.interface';
 export * from './mcp-tool.interface';
 export * from './http-adapter.interface';
+export * from './validation-adapter.interface';

--- a/src/mcp/interfaces/mcp-options.interface.ts
+++ b/src/mcp/interfaces/mcp-options.interface.ts
@@ -1,5 +1,6 @@
 import { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
 import { CanActivate, ModuleMetadata, Type } from '@nestjs/common';
+import { IValidationAdapter } from './validation-adapter.interface';
 
 export enum McpTransportType {
   SSE = 'sse',
@@ -26,6 +27,7 @@ export interface McpOptions {
   apiPrefix?: string;
   guards?: Type<CanActivate>[];
   decorators?: ClassDecorator[];
+  validationAdapter?: IValidationAdapter;
   sse?: {
     pingEnabled?: boolean;
     pingIntervalMs?: number;

--- a/src/mcp/interfaces/validation-adapter.interface.ts
+++ b/src/mcp/interfaces/validation-adapter.interface.ts
@@ -1,0 +1,20 @@
+
+export interface IValidationAdapter {
+  /**
+   * Validates the given data against a schema.
+   * @param schema The schema to validate against (e.g., a Zod schema or a class-validator class).
+   * @param data The data to validate.
+   * @returns A promise that resolves to a success or error object.
+   */
+  validate(
+    schema: any,
+    data: any,
+  ): Promise<{ success: true; data: any } | { success: false; error: any }>;
+
+  /**
+   * Converts the given schema into a JSON Schema representation.
+   * @param schema The schema to convert.
+   * @returns A promise that resolves to the JSON Schema object.
+   */
+  toJsonSchema(schema: any): Promise<any>;
+}

--- a/src/mcp/services/mcp-executor.service.ts
+++ b/src/mcp/services/mcp-executor.service.ts
@@ -6,6 +6,8 @@ import { McpToolsHandler } from './handlers/mcp-tools.handler';
 import { McpResourcesHandler } from './handlers/mcp-resources.handler';
 import { McpPromptsHandler } from './handlers/mcp-prompts.handler';
 import { HttpRequest } from '../interfaces/http-adapter.interface';
+import { MCP_VALIDATION_ADAPTER } from '../decorators';
+import { IValidationAdapter } from '../interfaces';
 
 /**
  * Request-scoped service for executing MCP tools
@@ -21,8 +23,14 @@ export class McpExecutorService {
     moduleRef: ModuleRef,
     registry: McpRegistryService,
     @Inject('MCP_MODULE_ID') mcpModuleId: string,
+    @Inject(MCP_VALIDATION_ADAPTER) validationAdapter: IValidationAdapter,
   ) {
-    this.toolsHandler = new McpToolsHandler(moduleRef, registry, mcpModuleId);
+    this.toolsHandler = new McpToolsHandler(
+      moduleRef,
+      registry,
+      mcpModuleId,
+      validationAdapter,
+    );
     this.resourcesHandler = new McpResourcesHandler(
       moduleRef,
       registry,
@@ -32,6 +40,7 @@ export class McpExecutorService {
       moduleRef,
       registry,
       mcpModuleId,
+      validationAdapter,
     );
   }
 
@@ -46,3 +55,4 @@ export class McpExecutorService {
     this.promptsHandler.registerHandlers(mcpServer, httpRequest);
   }
 }
+

--- a/src/mcp/services/mcp-registry.service.spec.ts
+++ b/src/mcp/services/mcp-registry.service.spec.ts
@@ -9,6 +9,7 @@ import { McpRegistryService } from './mcp-registry.service';
 import { DiscoveryService, MetadataScanner } from '@nestjs/core';
 import { Tool } from '../decorators/tool.decorator';
 import { McpModule } from '../mcp.module';
+import { MCP_VALIDATION_ADAPTER } from '../decorators';
 
 describe('McpRegistryService', () => {
   let service: McpRegistryService;
@@ -37,6 +38,13 @@ describe('McpRegistryService', () => {
           useValue: {
             getProviders: jest.fn(() => []),
             getControllers: jest.fn(() => []),
+          },
+        },
+        {
+          provide: MCP_VALIDATION_ADAPTER,
+          useValue: {
+            toJsonSchema: jest.fn().mockReturnValue({ type: 'object' }),
+            validate: jest.fn().mockResolvedValue({ success: true }),
           },
         },
         MetadataScanner,
@@ -176,10 +184,19 @@ describe('McpRegistryService - Multiple discovery roots', () => {
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [ModuleA, ModuleB],
+      providers: [
+        {
+          provide: MCP_VALIDATION_ADAPTER,
+          useValue: {
+            toJsonSchema: jest.fn().mockReturnValue({ type: 'object' }),
+            validate: jest.fn().mockResolvedValue({ success: true }),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<McpRegistryService>(McpRegistryService);
-    service.onApplicationBootstrap();
+    await service.whenReady();
   });
 
   it('server-a discovered toolA only', () => {
@@ -242,10 +259,19 @@ describe('McpRegistryService - Single discovery root with multiple MCP servers',
   beforeAll(async () => {
     const module: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
+      providers: [
+        {
+          provide: MCP_VALIDATION_ADAPTER,
+          useValue: {
+            toJsonSchema: jest.fn().mockReturnValue({ type: 'object' }),
+            validate: jest.fn().mockResolvedValue({ success: true }),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<McpRegistryService>(McpRegistryService);
-    service.onApplicationBootstrap();
+    await service.whenReady();
   });
 
   it('server-a discovered the tool', () => {

--- a/src/mcp/transport/stdio.service.ts
+++ b/src/mcp/transport/stdio.service.ts
@@ -29,6 +29,8 @@ export class StdioService implements OnApplicationBootstrap {
     }
     this.logger.log('Bootstrapping MCP STDIO...');
 
+    await this.toolRegistry.whenReady();
+
     // Create a new MCP server instance with dynamic capabilities
     const capabilities = buildMcpCapabilities(
       this.mcpModuleId,

--- a/tests/mcp-validation-adapter.e2e.spec.ts
+++ b/tests/mcp-validation-adapter.e2e.spec.ts
@@ -1,0 +1,176 @@
+import { INestApplication, Injectable } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { z } from 'zod';
+import { IsString } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+import { McpModule, Tool } from '../src/mcp';
+import { ClassValidatorAdapter, ZodValidationAdapter } from '../src/mcp/adapters';
+import { createStreamableClient } from './utils';
+import { McpError, ErrorCode, CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+// --- Zod-based Tool ---
+const zodToolSchema = z.object({
+  name: z.string(),
+});
+
+@Injectable()
+class ZodToolProvider {
+  @Tool({
+    name: 'zod_tool',
+    description: 'A tool using Zod',
+    parameters: zodToolSchema,
+  })
+  zodTool({ name }: z.infer<typeof zodToolSchema>) {
+    return `Hello, ${name}`;
+  }
+}
+
+// --- ClassValidator-based Tool ---
+class ClassValidatorDto {
+  @ApiProperty()
+  @IsString()
+  name: string;
+}
+
+@Injectable()
+class ClassValidatorToolProvider {
+  @Tool({
+    name: 'class_validator_tool',
+    description: 'A tool using class-validator',
+    parameters: ClassValidatorDto,
+  })
+  classValidatorTool({ name }: ClassValidatorDto) {
+    return `Hello, ${name}`;
+  }
+}
+
+describe('Validation Adapter (e2e)', () => {
+  let app: INestApplication;
+  let port: number;
+
+  describe('ZodValidationAdapter (default)', () => {
+    beforeAll(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          McpModule.forRoot({
+            name: 'zod-test-server',
+            version: '1.0.0',
+            // No adapter provided, should use default ZodValidationAdapter
+          }),
+        ],
+        providers: [ZodToolProvider],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.listen(0);
+      port = (app.getHttpServer().address() as import('net').AddressInfo).port;
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('should generate correct JSON schema for a Zod tool', async () => {
+      const client = await createStreamableClient(port);
+      const { tools } = await client.listTools();
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('zod_tool');
+      expect(tools[0].inputSchema).toEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        additionalProperties: false,
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+        required: ['name'],
+      });
+      await client.close();
+    });
+
+    it('should execute a Zod tool with valid params', async () => {
+      const client = await createStreamableClient(port);
+      const result = (await client.callTool({
+        name: 'zod_tool',
+        arguments: { name: 'World' },
+      })) as CallToolResult;
+      expect(result.content[0].text).toContain('Hello, World');
+      await client.close();
+    });
+
+    it('should fail a Zod tool with invalid params', async () => {
+      const client = await createStreamableClient(port);
+      await expect(
+        client.callTool({ name: 'zod_tool', arguments: { name: 123 } }),
+      ).rejects.toThrow(McpError);
+      await client.close();
+    });
+  });
+
+  describe('ClassValidatorAdapter', () => {
+    beforeAll(async () => {
+      const moduleRef = await Test.createTestingModule({
+        imports: [
+          McpModule.forRoot({
+            name: 'class-validator-test-server',
+            version: '1.0.0',
+            validationAdapter: new ClassValidatorAdapter(),
+          }),
+        ],
+        providers: [ClassValidatorToolProvider],
+      }).compile();
+
+      app = moduleRef.createNestApplication();
+      await app.listen(0);
+      port = (app.getHttpServer().address() as import('net').AddressInfo).port;
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+
+    it('should generate correct JSON schema for a class-validator tool', async () => {
+      const client = await createStreamableClient(port);
+      const { tools } = await client.listTools();
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe('class_validator_tool');
+      expect(tools[0].inputSchema).toEqual({
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+        },
+        required: ['name'],
+      });
+      await client.close();
+    });
+
+    it('should execute a class-validator tool with valid params', async () => {
+      const client = await createStreamableClient(port);
+      const result = (await client.callTool({
+        name: 'class_validator_tool',
+        arguments: { name: 'Class' },
+      })) as CallToolResult;
+      expect(result.content[0].text).toContain('Hello, Class');
+      await client.close();
+    });
+
+    it('should fail a class-validator tool with invalid params', async () => {
+      const client = await createStreamableClient(port);
+      try {
+        await client.callTool({
+          name: 'class_validator_tool',
+          arguments: { name: 123 },
+        });
+        fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(McpError);
+        expect(e.code).toBe(ErrorCode.InvalidParams);
+      }
+      await client.close();
+    });
+  });
+});


### PR DESCRIPTION
FIxes: #146 

This pull request refactors the validation layer to be fully pluggable, removing the previous tight coupling to Zod and allowing developers to integrate any validation library.

Previously, the framework required the use of Zod for all input schema validation. This change introduces a `ValidationAdapter` interface, which decouples the core engine from any specific validation implementation. This allows developers to use their preferred validation library by creating a simple **adapter.**

### Solution

This pull request addresses these issues by providing a robust and well-documented `ZodValidationAdapter`.

1.  **Create `ZodValidationAdapter` and `ClassValidatorAdapter`:**
    *   Created the `toJsonSchema` implementation in both `ZodValidationAdapter` and `ClassValidatorAdapter` and other features.
    *   Updated the corresponding unit and e2e tests to assert the correct JSON schema output, accounting for default properties like `$schema` added by the `zod-to-json-schema` library.

2.  **Add Documentation:**
    *   Enhanced the current `tools.md` with the new adapter addition. 
    *   Created a new documentation file, `docs/validation-adapters.md`, which explains how to use validation adapters.
    *   The document provides clear instructions and code examples for implementing both the existing `ClassValidatorValidationAdapter` and the new `ZodValidationAdapter`.

These changes make the framework more flexible by officially supporting Zod for validation, improve code quality by fixing bugs and type errors, and enhance developer experience with proper testing and documentation.