### PR TITLE
fix(tools): use validated data for structuredContent in formatToolResult

### DIFF
--- a/src/mcp/services/handlers/mcp-tools.handler.spec.ts
+++ b/src/mcp/services/handlers/mcp-tools.handler.spec.ts
@@ -1,0 +1,41 @@
+import { McpError } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+import { McpToolsHandler } from './mcp-tools.handler';
+
+const formatToolResult = McpToolsHandler.prototype['formatToolResult'].bind({
+  buildDefaultContentBlock: McpToolsHandler.prototype['buildDefaultContentBlock'],
+});
+
+const schema = z.object({ name: z.string(), age: z.number() });
+
+describe('formatToolResult', () => {
+  it('strips extra keys from structuredContent when outputSchema is set', () => {
+    const result = formatToolResult({ name: 'Alice', age: 30, extra: true }, schema);
+
+    expect(result.structuredContent).toEqual({ name: 'Alice', age: 30 });
+    expect(result.structuredContent).not.toHaveProperty('extra');
+  });
+
+  it('keeps the original result (with extra keys) in the content text block', () => {
+    const result = formatToolResult({ name: 'Alice', age: 30, extra: true }, schema);
+    const text = JSON.parse(result.content[0].text);
+
+    expect(text).toHaveProperty('extra', true);
+  });
+
+  it('throws McpError when result does not match outputSchema', () => {
+    expect(() => formatToolResult({ name: 'Alice' }, schema)).toThrow(McpError);
+  });
+
+  it('wraps result in content block when no outputSchema is provided', () => {
+    const result = formatToolResult({ anything: 42 });
+
+    expect(result.structuredContent).toBeUndefined();
+    expect(result.content[0].text).toBe('{"anything":42}');
+  });
+
+  it('returns as-is when result already has a content array', () => {
+    const existing = { content: [{ type: 'text', text: 'hi' }] };
+    expect(formatToolResult(existing, schema)).toBe(existing);
+  });
+});

--- a/src/mcp/services/handlers/mcp-tools.handler.ts
+++ b/src/mcp/services/handlers/mcp-tools.handler.ts
@@ -73,7 +73,7 @@ export class McpToolsHandler extends McpHandlerBase {
         );
       }
       return {
-        structuredContent: result,
+        structuredContent: validation.data,
         content: this.buildDefaultContentBlock(result),
       };
     }


### PR DESCRIPTION
`formatToolResult` validates the tool result via `safeParse` but passes the original `result` to `structuredContent`, so extra keys that Zod strips in default mode are still present. MCP clients that validate `structuredContent` against the JSON Schema (e.g. MCP Inspector) then reject the response with `additionalProperties` errors.

This PR uses `validation.data` for `structuredContent` so the payload matches the declared output schema. The `content` text block keeps the full `result` for debugging visibility.

Closes #188

Made with Cursor