### PR TITLE
fix(tool-guards): pass body and params to guard execution context

### DIFF
--- a/src/mcp/decorators/tool-guards.decorator.ts
+++ b/src/mcp/decorators/tool-guards.decorator.ts
@@ -13,7 +13,12 @@ export const MCP_GUARDS_METADATA_KEY = 'mcp:guards';
  * describes exactly what IS available.
  *
  * Available:
- * - `switchToHttp().getRequest()` - the real HTTP request object
+ * - `switchToHttp().getRequest()` - the HTTP request object, enriched with:
+ *   - `body` - during `tools/call`, contains the validated tool arguments;
+ *              during `tools/list`, contains the raw HTTP request body (if any)
+ *   - `params` - parsed route params from the HTTP adapter
+ *   - `user` - if set by a transport-level auth guard
+ *   - `headers` - original request headers
  * - `getClass()` - the tool's provider class (works with Reflector)
  * - `getHandler()` - the tool's method reference (works with Reflector)
  * - `getType()` - always returns `'http'`

--- a/src/mcp/services/handlers/mcp-tools.handler.ts
+++ b/src/mcp/services/handlers/mcp-tools.handler.ts
@@ -98,10 +98,16 @@ export class McpToolsHandler extends McpHandlerBase {
    * Only the fields documented in ToolGuardExecutionContext are available.
    * Invalid fields throw with a descriptive message rather than silently
    * returning garbage.
+   *
+   * The request object returned by `switchToHttp().getRequest()` is the raw
+   * framework request enriched with `body` and `params` from the adapted
+   * HttpRequest. During `tools/call`, `toolArguments` overrides `body` so
+   * guards can inspect the validated tool input.
    */
   private createToolGuardExecutionContext(
     httpRequest: HttpRequest,
     tool: DiscoveredCapability<ToolMetadata>,
+    toolArguments?: Record<string, unknown>,
   ): ToolGuardExecutionContext & ExecutionContext {
     const providerClass = tool.providerClass as Type;
     const methodHandler =
@@ -115,9 +121,20 @@ export class McpToolsHandler extends McpHandlerBase {
       );
     };
 
+    // Build the guard request from the raw request, enriched with parsed body and params.
+    // During tools/call, toolArguments is passed so guards can inspect the tool input as `body`.
+    const guardRequest = Object.assign(
+      Object.create(Object.getPrototypeOf(httpRequest.raw ?? {})),
+      httpRequest.raw ?? {},
+      {
+        body: toolArguments ?? httpRequest.body,
+        params: httpRequest.params ?? {},
+      },
+    );
+
     return {
       switchToHttp: () => ({
-        getRequest: <T = unknown>() => httpRequest.raw as T,
+        getRequest: <T = unknown>() => guardRequest as T,
         getResponse: () => unavailable('switchToHttp().getResponse()'),
         getNext: () => unavailable('switchToHttp().getNext()'),
       }),
@@ -138,6 +155,7 @@ export class McpToolsHandler extends McpHandlerBase {
   private async checkToolGuards(
     tool: DiscoveredCapability<ToolMetadata>,
     httpRequest: HttpRequest,
+    toolArguments?: Record<string, unknown>,
   ): Promise<boolean> {
     const guards = tool.metadata.guards;
     if (!guards || guards.length === 0) {
@@ -153,7 +171,7 @@ export class McpToolsHandler extends McpHandlerBase {
       return false;
     }
 
-    const context = this.createToolGuardExecutionContext(httpRequest, tool);
+    const context = this.createToolGuardExecutionContext(httpRequest, tool, toolArguments);
 
     for (const GuardClass of guards) {
       try {
@@ -310,7 +328,7 @@ export class McpToolsHandler extends McpHandlerBase {
         );
 
         // Validate @ToolGuards()
-        const guardsPassed = await this.checkToolGuards(toolInfo, httpRequest);
+        const guardsPassed = await this.checkToolGuards(toolInfo, httpRequest, request.params.arguments as Record<string, unknown>);
         if (!guardsPassed) {
           throw new McpError(
             ErrorCode.InvalidRequest,

--- a/tests/mcp-tool-guards.e2e.spec.ts
+++ b/tests/mcp-tool-guards.e2e.spec.ts
@@ -80,6 +80,28 @@ class ResponseAccessGuard implements CanActivate {
 }
 
 /**
+ * Guard that checks entity ownership via request.body (tool arguments).
+ * Simulates a real-world entity-modify guard that reads the tool input
+ * to determine if the user owns the entity being modified.
+ */
+@Injectable()
+class OwnershipGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const body = request?.body;
+    const user = request?.user;
+
+    // During tools/list, body may be undefined — allow listing
+    if (!body || !body.ownerId) {
+      return true;
+    }
+
+    // During tools/call, check that user owns the entity
+    return body.ownerId === user?.id;
+  }
+}
+
+/**
  * Mock transport-level guard that parses Authorization header and sets user on request.
  * Allows unauthenticated requests through for per-tool auth to handle.
  */
@@ -94,17 +116,17 @@ class MockTransportAuthGuard implements CanActivate {
     }
 
     if (authHeader.includes('admin-token')) {
-      request.user = { role: 'admin', name: 'Admin', asyncAllowed: true };
+      request.user = { id: 'admin-1', role: 'admin', name: 'Admin', asyncAllowed: true };
       return true;
     }
 
     if (authHeader.includes('user-token')) {
-      request.user = { role: 'user', name: 'Regular User' };
+      request.user = { id: 'user-1', role: 'user', name: 'Regular User' };
       return true;
     }
 
     if (authHeader.includes('async-token')) {
-      request.user = { role: 'viewer', name: 'Async User', asyncAllowed: true };
+      request.user = { id: 'async-1', role: 'viewer', name: 'Async User', asyncAllowed: true };
       return true;
     }
 
@@ -201,6 +223,19 @@ class GuardedTools {
   async badGuardTool() {
     return { content: [{ type: 'text', text: 'Should never execute' }] };
   }
+
+  @Tool({
+    name: 'ownership-tool',
+    description: 'Tool with an ownership guard that reads request.body',
+    parameters: z.object({
+      ownerId: z.string(),
+      title: z.string(),
+    }),
+  })
+  @ToolGuards([OwnershipGuard])
+  async ownershipTool({ ownerId, title }) {
+    return { content: [{ type: 'text', text: `Updated: ${title} (owner: ${ownerId})` }] };
+  }
 }
 
 describe('E2E: Tool Guards via @ToolGuards()', () => {
@@ -243,6 +278,7 @@ describe('E2E: Tool Guards via @ToolGuards()', () => {
           AsyncGuard,
           ReflectorGuard,
           ResponseAccessGuard,
+          OwnershipGuard,
         ],
       }).compile();
 
@@ -497,6 +533,52 @@ describe('E2E: Tool Guards via @ToolGuards()', () => {
         expect(
           (result.content as { type: string; text: string }[])[0].text,
         ).toBe('Echo: hello world');
+
+        await client.close();
+      });
+    });
+
+    describe('Guard access to tool arguments (request.body)', () => {
+      it('should list ownership-guarded tool (guard allows listing when no body)', async () => {
+        const client = await createClient(testPort, {
+          Authorization: 'Bearer user-token',
+        });
+
+        const tools = await client.listTools();
+        const toolNames = tools.tools.map((t) => t.name);
+        expect(toolNames).toContain('ownership-tool');
+
+        await client.close();
+      });
+
+      it('should allow execution when user owns the entity', async () => {
+        const client = await createClient(testPort, {
+          Authorization: 'Bearer user-token',
+        });
+
+        const result = await client.callTool({
+          name: 'ownership-tool',
+          arguments: { ownerId: 'user-1', title: 'My Recipe' },
+        });
+
+        expect(
+          (result.content as { type: string; text: string }[])[0].text,
+        ).toBe('Updated: My Recipe (owner: user-1)');
+
+        await client.close();
+      });
+
+      it('should deny execution when user does not own the entity', async () => {
+        const client = await createClient(testPort, {
+          Authorization: 'Bearer user-token',
+        });
+
+        await expect(
+          client.callTool({
+            name: 'ownership-tool',
+            arguments: { ownerId: 'someone-else', title: 'Not My Recipe' },
+          }),
+        ).rejects.toThrow();
 
         await client.close();
       });


### PR DESCRIPTION
## Summary

Guards using `@ToolGuards()` currently only receive `httpRequest.raw` (Node's `IncomingMessage`) via `switchToHttp().getRequest()`. This object lacks parsed `body` and `params`, making it impossible for guards to:

1. Inspect tool arguments during `tools/call` (e.g., for entity ownership checks)
2. Access route params from the HTTP adapter

### The fix

`createToolGuardExecutionContext` now builds an enriched request object that includes:
- **`body`** — during `tools/call`, set to the validated tool arguments; during `tools/list`, set to the raw HTTP body (if any)
- **`params`** — parsed route params from the HTTP adapter

This is done by creating a shallow copy of the raw request and assigning the parsed fields from the adapted `HttpRequest`:

```typescript
const guardRequest = Object.assign(
  Object.create(Object.getPrototypeOf(httpRequest.raw ?? {})),
  httpRequest.raw ?? {},
  {
    body: toolArguments ?? httpRequest.body,
    params: httpRequest.params ?? {},
  },
);
```

### Use case

This enables entity-ownership guards that check whether the authenticated user owns the entity being modified:

```typescript
@Injectable()
class OwnershipGuard implements CanActivate {
  canActivate(context: ExecutionContext): boolean {
    const request = context.switchToHttp().getRequest();
    const body = request?.body; // Now contains tool arguments during tools/call
    const user = request?.user;

    if (!body || !body.ownerId) return true; // Allow listing
    return body.ownerId === user?.id;         // Check ownership during call
  }
}
```

### Changes
- `createToolGuardExecutionContext` now accepts optional `toolArguments` and enriches the guard request with `body` and `params`
- `checkToolGuards` forwards tool arguments during `tools/call`
- Updated `ToolGuardExecutionContext` JSDoc to document available request properties
- Added e2e tests for ownership guard reading `request.body`

## Test plan
- [x] All 389 existing tests pass
- [x] New e2e test: ownership guard allows listing (no body during `tools/list`)
- [x] New e2e test: ownership guard allows execution when user owns entity
- [x] New e2e test: ownership guard denies execution when user doesn't own entity
- [x] Tested with both SSE and Streamable HTTP transports

🤖 Generated with [Claude Code](https://claude.com/claude-code)