### PR TITLE
fix(capabilities): advertise the MCP logging capability

### DIFF
--- a/src/mcp/utils/capabilities-builder.ts
+++ b/src/mcp/utils/capabilities-builder.ts
@@ -39,5 +39,10 @@ export function buildMcpCapabilities(
     };
   }
 
+  // The execution context always exposes `context.log.*`, which emits
+  // `notifications/message`. Per the MCP spec, a server that emits log message
+  // notifications MUST declare the `logging` capability.
+  capabilities.logging = capabilities.logging || {};
+
   return capabilities;
 }

--- a/tests/mcp-logging-capability.e2e.spec.ts
+++ b/tests/mcp-logging-capability.e2e.spec.ts
@@ -1,0 +1,63 @@
+import { INestApplication, Injectable } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { z } from 'zod';
+import { Tool } from '../src';
+import type { Context } from '../src';
+import { McpModule } from '../src/mcp/mcp.module';
+import { createStreamableClient } from './utils';
+
+@Injectable()
+class LoggingTool {
+  @Tool({
+    name: 'log-something',
+    description: 'A tool that emits a server log message',
+    parameters: z.object({}),
+  })
+  async run(_args, context: Context) {
+    context.log.info('hello from server');
+    return { content: [{ type: 'text', text: 'done' }] };
+  }
+}
+
+describe('MCP logging capability', () => {
+  let app: INestApplication;
+  let port: number;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        McpModule.forRoot({
+          name: 'logging-cap-server',
+          version: '0.0.1',
+          streamableHttp: {
+            enableJsonResponse: false,
+            sessionIdGenerator: () => Math.random().toString(36),
+            statelessMode: false,
+          },
+        }),
+      ],
+      providers: [LoggingTool],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.listen(0);
+    port = (app.getHttpServer().address() as import('net').AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('advertises the `logging` capability', async () => {
+    const client = await createStreamableClient(port);
+    const caps = client.getServerCapabilities();
+
+    // The server emits notifications/message via context.log.*, so per the MCP spec
+    // it MUST declare the `logging` capability.
+    expect(caps?.logging).toBeDefined();
+    // sanity: tools capability is still advertised alongside it
+    expect(caps?.tools).toBeDefined();
+
+    await client.close();
+  });
+});


### PR DESCRIPTION
## Summary

`context.log.*` already emits MCP log notifications (`notifications/message`), but the server never declares the `logging` capability at initialization. The [MCP spec](https://modelcontextprotocol.io/specification/latest/server/utilities/logging) says a server emitting log notifications **MUST** declare it:

> "Servers that emit log message notifications **MUST** declare the `logging` capability."

(Unrelated to the NestJS logger config in #140 — this is the protocol-level capability.)

## Changes

- Declare `capabilities.logging` in `capabilities-builder.ts` (respects any value passed via
  `McpOptions.capabilities`).
- Add an e2e regression test.

## Test

- New test: RED before, GREEN after. Full suite: 390/390 passing.

## Follow-up

A natural next step is a `logging/setLevel` handler so clients can control the log level (currently returns `-32601`). Happy to send that as a separate PR.
