### PR TITLE
feat(tools): context-aware tool schemas — resolve `parameters` per request/identity

### DIFF
--- a/src/mcp/decorators/tool.decorator.ts
+++ b/src/mcp/decorators/tool.decorator.ts
@@ -2,6 +2,7 @@ import { CanActivate, SetMetadata, Type } from '@nestjs/common';
 import { z } from 'zod';
 import { ToolAnnotations as SdkToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { MCP_TOOL_METADATA_KEY } from './constants';
+import type { HttpRequest } from '../interfaces/http-adapter.interface';
 
 /**
  * Security scheme type for MCP tools
@@ -10,10 +11,31 @@ export type SecurityScheme =
   | { type: 'noauth' }
   | { type: 'oauth2'; scopes?: string[] };
 
+/**
+ * Per-request context handed to a {@link ToolSchemaResolver}. It carries the
+ * adapted HTTP request and the authenticated user (when present) so a tool's
+ * input schema can depend on the caller's identity.
+ */
+export interface ToolSchemaContext {
+  /** The adapted HTTP request for this MCP call (undefined for STDIO). */
+  httpRequest: HttpRequest;
+  /** The authenticated user attached to `httpRequest.raw`, if any. */
+  user?: unknown;
+}
+
+/**
+ * A function form of a tool's `parameters` that resolves the Zod input schema
+ * from the caller's identity. It is invoked at BOTH `tools/list` rendering and
+ * `tools/call` validation with the same context, so the advertised schema and
+ * the validation schema can never disagree. Plain `z.ZodType` values are used
+ * as-is, so tools that do not opt in are unaffected.
+ */
+export type ToolSchemaResolver = (ctx: ToolSchemaContext) => z.ZodType;
+
 export interface ToolMetadata {
   name: string;
   description: string;
-  parameters?: z.ZodType;
+  parameters?: z.ZodType | ToolSchemaResolver;
   outputSchema?: z.ZodType;
   annotations?: SdkToolAnnotations;
   _meta?: Record<string, any>;
@@ -31,7 +53,7 @@ export interface ToolAnnotations extends SdkToolAnnotations {}
 export interface ToolOptions {
   name?: string;
   description?: string;
-  parameters?: z.ZodType;
+  parameters?: z.ZodType | ToolSchemaResolver;
   outputSchema?: z.ZodType;
   annotations?: ToolAnnotations;
   _meta?: Record<string, any>;
@@ -42,7 +64,8 @@ export interface ToolOptions {
  * @param {Object} options - The options for the decorator
  * @param {string} options.name - The name of the tool
  * @param {string} options.description - The description of the tool
- * @param {z.ZodType} [options.parameters] - The parameters of the tool
+ * @param {z.ZodType | ToolSchemaResolver} [options.parameters] - The parameters of the tool.
+ *   May be a Zod schema, or a `(ctx) => z.ZodType` resolver evaluated per identity.
  * @param {z.ZodType} [options.outputSchema] - The output schema of the tool
  * @returns {MethodDecorator} - The decorator
  */

--- a/src/mcp/interfaces/dynamic-tool.interface.ts
+++ b/src/mcp/interfaces/dynamic-tool.interface.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod';
 import { Context } from './mcp-tool.interface';
-import { ToolAnnotations } from '../decorators/tool.decorator';
+import {
+  ToolAnnotations,
+  ToolSchemaResolver,
+} from '../decorators/tool.decorator';
 
 /**
  * Handler function signature for dynamically registered tools.
@@ -34,8 +37,8 @@ export interface DynamicToolDefinition {
   name: string;
   /** Description shown to the LLM */
   description: string;
-  /** Zod schema for input validation */
-  parameters?: z.ZodType;
+  /** Zod schema for input validation, or a per-identity resolver `(ctx) => z.ZodType` */
+  parameters?: z.ZodType | ToolSchemaResolver;
   /** Zod schema for output validation */
   outputSchema?: z.ZodType;
   /** MCP tool annotations */

--- a/src/mcp/services/handlers/mcp-tools.handler.ts
+++ b/src/mcp/services/handlers/mcp-tools.handler.ts
@@ -19,7 +19,11 @@ import {
   DiscoveredCapability,
   McpRegistryDiscoveryService,
 } from '../mcp-registry-discovery.service';
-import { ToolGuardExecutionContext, ToolMetadata } from '../../decorators';
+import {
+  ToolGuardExecutionContext,
+  ToolMetadata,
+  ToolSchemaContext,
+} from '../../decorators';
 import { McpHandlerBase } from './mcp-handler.base';
 import { ZodType } from 'zod';
 import { HttpRequest } from '../../interfaces/http-adapter.interface';
@@ -195,6 +199,23 @@ export class McpToolsHandler extends McpHandlerBase {
 
     return true;
   }
+
+  /**
+   * Resolves a tool's `parameters` for the current identity.
+   *
+   * When `parameters` is a resolver function, it is invoked with the
+   * per-request {@link ToolSchemaContext} so that `tools/list` rendering and
+   * `tools/call` validation always use the same schema (they can never
+   * disagree). Plain Zod schemas pass through unchanged, so tools that do not
+   * opt into per-identity schemas are byte-identical to before.
+   */
+  private resolveParameters(
+    parameters: ToolMetadata['parameters'],
+    ctx: ToolSchemaContext,
+  ): ZodType | undefined {
+    return typeof parameters === 'function' ? parameters(ctx) : parameters;
+  }
+
   registerHandlers(mcpServer: McpServer, httpRequest: HttpRequest) {
     if (this.registry.getTools(this.mcpModuleId).length === 0) {
       this.logger.debug('No tools registered, skipping tool handlers');
@@ -207,6 +228,10 @@ export class McpToolsHandler extends McpHandlerBase {
       const user = httpRequest.raw
         ? (httpRequest.raw as McpRequestWithUser).user
         : undefined;
+
+      // Context for per-identity schema resolution. Built once and reused for
+      // every tool so the advertised schema matches what tools/call validates.
+      const toolSchemaContext: ToolSchemaContext = { httpRequest, user };
 
       // Get all tools and filter based on user permissions
       // STDIO: If no httpRequest.raw, disable guards (local dev mode)
@@ -259,9 +284,10 @@ export class McpToolsHandler extends McpHandlerBase {
           };
         }
 
-        // Add input schema if defined
+        // Add input schema if defined. Resolve per-identity schemas first so
+        // the advertised inputSchema matches what tools/call will validate.
         const normalizedInputParameters = normalizeObjectSchema(
-          tool.metadata.parameters,
+          this.resolveParameters(tool.metadata.parameters, toolSchemaContext),
         );
         if (normalizedInputParameters) {
           toolSchema['inputSchema'] = toJsonSchemaCompat(
@@ -315,6 +341,7 @@ export class McpToolsHandler extends McpHandlerBase {
         const user = httpRequest.raw
           ? (httpRequest.raw as McpRequestWithUser).user
           : undefined;
+        const toolSchemaContext: ToolSchemaContext = { httpRequest, user };
         const effectiveModuleHasGuards = httpRequest.raw
           ? this.moduleHasGuards
           : false;
@@ -337,9 +364,14 @@ export class McpToolsHandler extends McpHandlerBase {
         }
 
         try {
-          // Validate input parameters against the tool's schema
-          if (toolInfo.metadata.parameters) {
-            const validation = toolInfo.metadata.parameters.safeParse(
+          // Validate input parameters against the tool's schema. Resolve
+          // per-identity schemas with the SAME context used at tools/list time.
+          const resolvedParameters = this.resolveParameters(
+            toolInfo.metadata.parameters,
+            toolSchemaContext,
+          );
+          if (resolvedParameters) {
+            const validation = resolvedParameters.safeParse(
               request.params.arguments || {},
             );
             if (!validation.success) {

--- a/tests/mcp-per-identity-schema.e2e.spec.ts
+++ b/tests/mcp-per-identity-schema.e2e.spec.ts
@@ -1,0 +1,229 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  INestApplication,
+  Injectable,
+} from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { z } from 'zod';
+import {
+  McpTransportType,
+  PublicTool,
+  Tool,
+  ToolGuards,
+  ToolSchemaContext,
+} from '../src';
+import { McpModule } from '../src/mcp/mcp.module';
+import { createStreamableClient } from './utils';
+
+/**
+ * Per-identity tool schema resolution.
+ *
+ * Verifies that a tool's `parameters` may be a `(ctx) => z.ZodType` resolver
+ * evaluated per identity, that the schema advertised at `tools/list` is the
+ * SAME schema used to validate `tools/call`, that plain Zod schemas are
+ * unaffected (byte-identical across identities), and that `@ToolGuards()` still
+ * run BEFORE schema validation.
+ */
+
+/** Transport-level guard: maps a bearer token to a user with a role. */
+@Injectable()
+class MockAuthGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest();
+    const authHeader = request.headers?.authorization;
+    if (authHeader?.includes('admin-token')) {
+      request.user = { id: 'admin-1', role: 'admin' };
+    } else if (authHeader?.includes('user-token')) {
+      request.user = { id: 'user-1', role: 'user' };
+    }
+    return true; // allow through; per-tool guards handle authorization
+  }
+}
+
+/** Denies everyone — used to prove guards run before schema validation. */
+@Injectable()
+class DenyGuard implements CanActivate {
+  canActivate(): boolean {
+    return false;
+  }
+}
+
+const isAdmin = (ctx: ToolSchemaContext): boolean =>
+  (ctx.user as { role?: string } | undefined)?.role === 'admin';
+
+/**
+ * Example resolver: admins must supply `tenantId`; everyone else sees the base
+ * schema unchanged.
+ */
+const tenantScopedCreate = (ctx: ToolSchemaContext): z.ZodType =>
+  isAdmin(ctx)
+    ? z.object({ name: z.string(), tenantId: z.string() })
+    : z.object({ name: z.string() });
+
+@Injectable()
+class PerIdentityTools {
+  @Tool({
+    name: 'static-tool',
+    description: 'Plain static schema — must be identical for every identity',
+    parameters: z.object({ q: z.string() }),
+  })
+  @PublicTool()
+  async staticTool({ q }: { q: string }) {
+    return { content: [{ type: 'text', text: `q=${q}` }] };
+  }
+
+  @Tool({
+    name: 'per-identity-tool',
+    description: 'Schema depends on the caller identity',
+    parameters: tenantScopedCreate,
+  })
+  @PublicTool()
+  async perIdentityTool(args: { name: string; tenantId?: string }) {
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `created ${args.name}${
+            args.tenantId ? ` in tenant ${args.tenantId}` : ''
+          }`,
+        },
+      ],
+    };
+  }
+
+  @Tool({
+    name: 'always-deny-tool',
+    description: 'Guarded tool whose resolver would reject empty args',
+    parameters: tenantScopedCreate,
+  })
+  @ToolGuards([DenyGuard])
+  async alwaysDenyTool() {
+    return { content: [{ type: 'text', text: 'should never execute' }] };
+  }
+}
+
+describe('E2E: per-identity tool schema resolution', () => {
+  let app: INestApplication;
+  let testPort: number;
+
+  const clientFor = (token?: string) =>
+    createStreamableClient(
+      testPort,
+      token
+        ? { requestInit: { headers: { Authorization: `Bearer ${token}` } } }
+        : {},
+    );
+
+  const listTool = async (token: string | undefined, name: string) => {
+    const client = await clientFor(token);
+    try {
+      const { tools } = await client.listTools();
+      return tools.find((t) => t.name === name);
+    } finally {
+      await client.close();
+    }
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        McpModule.forRoot({
+          name: 'test-per-identity-server',
+          version: '0.0.1',
+          transport: McpTransportType.STREAMABLE_HTTP,
+          guards: [MockAuthGuard],
+          allowUnauthenticatedAccess: true,
+        }),
+      ],
+      providers: [PerIdentityTools, MockAuthGuard, DenyGuard],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.listen(0);
+    testPort = app.getHttpServer().address().port;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('static schemas are unaffected (byte-identical across identities)', () => {
+    it('renders the same inputSchema for admin and non-admin', async () => {
+      const adminStatic = await listTool('admin-token', 'static-tool');
+      const userStatic = await listTool('user-token', 'static-tool');
+
+      expect(adminStatic?.inputSchema).toBeDefined();
+      expect(adminStatic?.inputSchema).toEqual(userStatic?.inputSchema);
+      expect(adminStatic?.inputSchema?.required).toContain('q');
+    });
+  });
+
+  describe('per-identity resolution at tools/list', () => {
+    it('requires tenantId for an admin', async () => {
+      const tool = await listTool('admin-token', 'per-identity-tool');
+      expect(tool?.inputSchema?.properties).toHaveProperty('tenantId');
+      expect(tool?.inputSchema?.required).toContain('tenantId');
+    });
+
+    it('omits tenantId for a non-admin', async () => {
+      const tool = await listTool('user-token', 'per-identity-tool');
+      expect(tool?.inputSchema?.properties).not.toHaveProperty('tenantId');
+      expect(tool?.inputSchema?.required ?? []).not.toContain('tenantId');
+    });
+  });
+
+  describe('tools/call validates against the SAME resolved schema', () => {
+    it('accepts a non-admin call without tenantId', async () => {
+      const client = await clientFor('user-token');
+      const result = await client.callTool({
+        name: 'per-identity-tool',
+        arguments: { name: 'apples' },
+      });
+      expect(result.isError).toBeFalsy();
+      expect((result.content as { text: string }[])[0].text).toBe(
+        'created apples',
+      );
+      await client.close();
+    });
+
+    it('rejects an admin call that omits the now-required tenantId', async () => {
+      const client = await clientFor('admin-token');
+      const result = await client.callTool({
+        name: 'per-identity-tool',
+        arguments: { name: 'apples' },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as { text: string }[])[0].text).toMatch(
+        /Invalid parameters.*tenantId/,
+      );
+      await client.close();
+    });
+
+    it('accepts an admin call that includes tenantId', async () => {
+      const client = await clientFor('admin-token');
+      const result = await client.callTool({
+        name: 'per-identity-tool',
+        arguments: { name: 'apples', tenantId: '42' },
+      });
+      expect(result.isError).toBeFalsy();
+      expect((result.content as { text: string }[])[0].text).toBe(
+        'created apples in tenant 42',
+      );
+      await client.close();
+    });
+  });
+
+  describe('guards run before schema validation', () => {
+    it('denies via guard (not a validation error) when args would also be invalid', async () => {
+      const client = await clientFor('admin-token');
+      // Admin schema requires tenantId; omit it. If validation ran first we'd
+      // get an `isError` result. Because the guard runs first, the call is
+      // rejected outright with an access-denied McpError.
+      await expect(
+        client.callTool({ name: 'always-deny-tool', arguments: {} }),
+      ).rejects.toThrow(/permissions|denied/i);
+      await client.close();
+    });
+  });
+});


### PR DESCRIPTION
Implements the context-aware tool schemas proposed in #233.

**Draft, and based on `v1.9.11` — please read the caveat below before reviewing the mechanics.**

### What this does

Widens a tool's `parameters` to accept a resolver alongside a static schema:

```ts
export interface ToolSchemaContext {
  httpRequest: HttpRequest;
  user?: unknown;
}
export type ToolSchemaResolver = (ctx: ToolSchemaContext) => z.ZodType;

parameters?: z.ZodType | ToolSchemaResolver;
```

The resolver is invoked with the same per-request context at **both** consumption sites, via one shared helper:

- `tools/list` — resolved before `normalizeObjectSchema(...)` → `toJsonSchemaCompat(...)`
- `tools/call` — resolved before `.safeParse(...)`

That shared-context detail is the whole point: the advertised schema and the validating schema are produced by the same call, so they cannot drift. Drift here would be an authorization bug, not a cosmetic one.

```ts
@Tool({
  name: 'create-thing',
  parameters: (ctx) =>
    ctx.user?.isAdmin
      ? BaseInput.extend({ tenantId: z.string() })
      : BaseInput,
})
```

### Backward compatibility

Fully compatible. A `z.ZodType` passes through untouched — the zod→JSON-Schema pipeline is not modified at all, so static tools render byte-identical output. The type widens to a superset, so existing code compiles unchanged. Guards are unaffected and still run before resolution and validation.

### Tests

`tests/mcp-per-identity-schema.e2e.spec.ts` (7 tests) covers static pass-through byte-identical across identities, per-identity divergence at `tools/list`, list/validate agreement in both directions, and `@ToolGuards()` still running before schema validation.

### ⚠️ The base — this needs your call

This targets `main` but is built on **`v1.9.11`**, so GitHub will flag it as conflicting. That is expected, not an oversight: `main` has since moved to the 2.0 monorepo (#228), which relocated everything under `packages/mcp-nest/` and removed `mcp-tools.handler.ts` — the file this patch centers on. A direct rebase isn't meaningful; it's a re-implementation.

I'm opening this as a draft so the design and tests are concrete and reviewable, rather than asking you to evaluate a prose proposal.

The approach ports cleanly to 2.0, and arguably reads better there — both consumption sites now live together in `mcp.strategy.ts` (`normalizeObjectSchema` in the `ListTools` handler, `parameters.safeParse` in `CallTool`), so it's the same two-site change in one file instead of two.

**If you want this, I'm happy to redo it against 2.0** and close this draft, or keep it as the v1 reference. I just didn't want to invest in the port before knowing whether per-identity schemas are a direction you'd take in core at all — and equally happy to adjust the shape (naming, or whether the context should expose something narrower than the raw `httpRequest`).

We've been running this patch on a fork in production for a multi-tenant NestJS MCP server.
