### PR TITLE
fix(auth): refuse to boot when cookie-parser is missing + mount it in every OAuth example

### DIFF
--- a/docs/azure-ad-oauth-provider.md
+++ b/docs/azure-ad-oauth-provider.md
@@ -89,8 +89,15 @@ Copy these values for your application configuration:
 The Azure AD provider ships with the built-in authorization server package. Install it alongside `@rekog/mcp-nest`:
 
 ```bash
-npm install @rekog/mcp-nest-auth
+npm install @rekog/mcp-nest-auth cookie-parser
+npm install --save-dev @types/cookie-parser
 ```
+
+`cookie-parser` is required, not optional: `/auth/authorize` sets the
+`oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back off
+`req.cookies`. `McpAuthModule` does not register the middleware itself, so
+without `app.use(cookieParser())` the authorization request fails fast with a
+500 whose message names the missing middleware.
 
 ```typescript
 import { McpAuthModule, AzureADOAuthProvider } from '@rekog/mcp-nest-auth';
@@ -183,6 +190,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import type { Request } from 'express';
+import cookieParser from 'cookie-parser';
 import {
   McpHttpControllerFor,
   McpStrategy,
@@ -258,6 +266,10 @@ export class AppModule {}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Required for OAuth session management (this is NOT authentication).
+  app.use(cookieParser());
+
   app.enableCors({ origin: true, credentials: true });
 
   mcp.setHttpAdapter(app.getHttpAdapter());

--- a/docs/azure-ad-oauth-provider.md
+++ b/docs/azure-ad-oauth-provider.md
@@ -96,8 +96,8 @@ npm install --save-dev @types/cookie-parser
 `cookie-parser` is required, not optional: `/auth/authorize` sets the
 `oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back off
 `req.cookies`. `McpAuthModule` does not register the middleware itself, so
-without `app.use(cookieParser())` the authorization request fails fast with a
-500 whose message names the missing middleware.
+without `app.use(cookieParser())` the application refuses to start, with a
+bootstrap error naming the missing middleware.
 
 ```typescript
 import { McpAuthModule, AzureADOAuthProvider } from '@rekog/mcp-nest-auth';

--- a/docs/azure-ad-provider.md
+++ b/docs/azure-ad-provider.md
@@ -54,11 +54,19 @@ Copy these values from your app registration:
 The Azure AD provider ships with the built-in authorization server package. Install it alongside `@rekog/mcp-nest`:
 
 ```bash
-npm install @rekog/mcp-nest-auth
+npm install @rekog/mcp-nest-auth cookie-parser
+npm install --save-dev @types/cookie-parser
 ```
+
+`cookie-parser` is required, not optional: `/auth/authorize` sets the
+`oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back off
+`req.cookies`. `McpAuthModule` does not register the middleware itself, so
+without `app.use(cookieParser())` the authorization request fails fast with a
+500 whose message names the missing middleware.
 
 ```typescript
 import { Controller, Module, UseGuards } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
 import {
   McpHttpControllerFor,
   McpStrategy,
@@ -121,6 +129,7 @@ above validates the Bearer JWT and sets `req.user` (see the
 
 ```typescript
 const app = await NestFactory.create(AppModule);
+app.use(cookieParser()); // OAuth session plumbing — see the note above
 mcp.setHttpAdapter(app.getHttpAdapter());
 app.connectMicroservice({ strategy: mcp });
 await app.startAllMicroservices();

--- a/docs/azure-ad-provider.md
+++ b/docs/azure-ad-provider.md
@@ -61,8 +61,8 @@ npm install --save-dev @types/cookie-parser
 `cookie-parser` is required, not optional: `/auth/authorize` sets the
 `oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back off
 `req.cookies`. `McpAuthModule` does not register the middleware itself, so
-without `app.use(cookieParser())` the authorization request fails fast with a
-500 whose message names the missing middleware.
+without `app.use(cookieParser())` the application refuses to start, with a
+bootstrap error naming the missing middleware.
 
 ```typescript
 import { Controller, Module, UseGuards } from '@nestjs/common';

--- a/docs/built-in-authorization-server.md
+++ b/docs/built-in-authorization-server.md
@@ -208,6 +208,7 @@ Pass a field name to project a single property, e.g. `@McpUser('email') email?: 
 | `clientIdMetadataDocuments` | `{ enabled?: boolean; allowInsecureClientIdScheme?: boolean; cacheTtlMs?: number; maxCacheEntries?: number; timeoutMs?: number; maxDocumentBytes?: number }` | `{ enabled: false, allowInsecureClientIdScheme: false, cacheTtlMs: 300000, maxCacheEntries: 256, timeoutMs: 5000, maxDocumentBytes: 5120 }` | Accept URL-shaped `client_id`s by fetching the client's own metadata document. See [CIMD](#client-id-metadata-documents-cimd) |
 | `cookieSecure` | `boolean` | `nodeEnv === 'production'` | Use secure cookies |
 | `cookieMaxAge` | `number` | `24 * 60 * 60 * 1000` | Cookie expiration (24 hours) |
+| `skipCookieParserCheck` | `boolean` | `false` | Allow the app to start without `cookie-parser` mounted. Only for hosts that populate `req.cookies` another way — the check finds the middleware by name and cannot see a wrapped or re-exported one. |
 | `oauthSessionExpiresIn` | `number` | `10 * 60 * 1000` | OAuth session timeout (10 minutes) |
 | `authCodeExpiresIn` | `number` | `10 * 60 * 1000` | Authorization code timeout (10 minutes) |
 | `endpoints` | `object` | See below | Custom endpoint paths |
@@ -874,13 +875,16 @@ DATABASE_URL=postgresql://user:password@localhost:5432/oauth_db
 1. **JWT Secret Too Short**: Ensure `jwtSecret` is at least 32 characters
 2. **Invalid Redirect URI**: OAuth provider redirect URI must match `{serverUrl}/{apiPrefix}/callback`
 3. **CORS Issues**: Enable CORS with `credentials: true` for browser-based clients
-4. **A 500 from `/auth/authorize` naming `cookie-parser`**: `app.use(cookieParser())`
+4. **The app refuses to start, naming `cookie-parser`**: `app.use(cookieParser())`
    is missing. `/auth/authorize` sets the `oauth_session` / `oauth_state`
    cookies and the callback reads them back off `req.cookies`, which Express
-   only populates when `cookie-parser` is mounted — `McpAuthModule` cannot
-   register the middleware for you. The request is refused before the redirect
-   to the IdP, so you never get sent on a login round-trip that was going to
-   fail on the way back.
+   only populates when `cookie-parser` is mounted — and `McpAuthModule` cannot
+   register the middleware for you, since middleware belongs to your bootstrap.
+   A server that cannot complete the handshake should not accept traffic, so
+   this fails at boot rather than on the callback of the first user who tries to
+   log in. If you populate `req.cookies` by some other means — a wrapped or
+   re-exported cookie-parser, `@fastify/cookie` — the check cannot see it by
+   name; set `skipCookieParserCheck: true` to opt out.
 5. **Cookies not sent back**: the IdP's redirect URI host must match
    `serverUrl` exactly — cookies set on `localhost` are not sent to
    `127.0.0.1`.

--- a/docs/built-in-authorization-server.md
+++ b/docs/built-in-authorization-server.md
@@ -874,4 +874,13 @@ DATABASE_URL=postgresql://user:password@localhost:5432/oauth_db
 1. **JWT Secret Too Short**: Ensure `jwtSecret` is at least 32 characters
 2. **Invalid Redirect URI**: OAuth provider redirect URI must match `{serverUrl}/{apiPrefix}/callback`
 3. **CORS Issues**: Enable CORS with `credentials: true` for browser-based clients
-4. **Cookie Problems**: Ensure `cookieParser()` middleware is installed for session management
+4. **A 500 from `/auth/authorize` naming `cookie-parser`**: `app.use(cookieParser())`
+   is missing. `/auth/authorize` sets the `oauth_session` / `oauth_state`
+   cookies and the callback reads them back off `req.cookies`, which Express
+   only populates when `cookie-parser` is mounted — `McpAuthModule` cannot
+   register the middleware for you. The request is refused before the redirect
+   to the IdP, so you never get sent on a login round-trip that was going to
+   fail on the way back.
+5. **Cookies not sent back**: the IdP's redirect URI host must match
+   `serverUrl` exactly — cookies set on `localhost` are not sent to
+   `127.0.0.1`.

--- a/docs/migration-to-v2.md
+++ b/docs/migration-to-v2.md
@@ -426,8 +426,8 @@ worked (and still works) by supplying a guard, e.g. `McpAuthJwtGuard`, into that
 same slot. Plain `app.use(...)`-style middleware for other HTTP concerns still
 works as usual, but don't reach for middleware to set `req.user` — use a guard.
 (One piece of middleware is not optional: `McpAuthModule`'s browser handshake
-needs `app.use(cookieParser())`; without it `/auth/authorize` fails with a 500
-naming the missing middleware. That is session plumbing, not authentication.)
+needs `app.use(cookieParser())`; without it the application refuses to start.
+That is session plumbing, not authentication.)
 
 - **Authenticate** with a NestJS guard on the MCP controller
   (`@UseGuards(YourGuard)`) that sets `req.user` (and throws

--- a/docs/migration-to-v2.md
+++ b/docs/migration-to-v2.md
@@ -423,9 +423,11 @@ Authentication is **guards-only** — this isn't a step down from v1, which neve
 had a supported middleware alternative either: `McpModule.forRoot({ guards })`
 applied guards directly to the generated controllers, and `McpAuthModule` itself
 worked (and still works) by supplying a guard, e.g. `McpAuthJwtGuard`, into that
-same slot. Plain `app.use(cookieParser())`-style middleware for unrelated HTTP
-concerns still works as usual, but don't reach for middleware to set `req.user`
-— use a guard.
+same slot. Plain `app.use(...)`-style middleware for other HTTP concerns still
+works as usual, but don't reach for middleware to set `req.user` — use a guard.
+(One piece of middleware is not optional: `McpAuthModule`'s browser handshake
+needs `app.use(cookieParser())`; without it `/auth/authorize` fails with a 500
+naming the missing middleware. That is session plumbing, not authentication.)
 
 - **Authenticate** with a NestJS guard on the MCP controller
   (`@UseGuards(YourGuard)`) that sets `req.user` (and throws

--- a/docs/per-tool-authorization-oauth.md
+++ b/docs/per-tool-authorization-oauth.md
@@ -38,8 +38,8 @@ npm install --save-dev @types/cookie-parser
 `cookie-parser` is not optional for the browser handshake: `/auth/authorize`
 sets the `oauth_session` and `oauth_state` cookies and `/auth/callback` reads
 them back off `req.cookies`. `McpAuthModule` does not register the middleware
-itself, so without `app.use(cookieParser())` the callback fails with
-`400 Missing OAuth session`.
+itself, so without `app.use(cookieParser())` the authorization request fails fast with a
+500 whose message names the missing middleware.
 
 ## The wiring
 
@@ -118,8 +118,8 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   // OAuth session plumbing (NOT authentication): /auth/callback reads the
-  // cookies /auth/authorize set. Omit this and the callback 400s with
-  // "Missing OAuth session".
+  // cookies /auth/authorize set. Omit this and /auth/authorize refuses the
+  // request with a 500 naming the missing middleware.
   app.use(cookieParser());
 
   strategy.setHttpAdapter(app.getHttpAdapter());

--- a/docs/per-tool-authorization-oauth.md
+++ b/docs/per-tool-authorization-oauth.md
@@ -38,8 +38,8 @@ npm install --save-dev @types/cookie-parser
 `cookie-parser` is not optional for the browser handshake: `/auth/authorize`
 sets the `oauth_session` and `oauth_state` cookies and `/auth/callback` reads
 them back off `req.cookies`. `McpAuthModule` does not register the middleware
-itself, so without `app.use(cookieParser())` the authorization request fails fast with a
-500 whose message names the missing middleware.
+itself, so without `app.use(cookieParser())` the application refuses to start, with a
+bootstrap error naming the missing middleware.
 
 ## The wiring
 
@@ -118,8 +118,7 @@ async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   // OAuth session plumbing (NOT authentication): /auth/callback reads the
-  // cookies /auth/authorize set. Omit this and /auth/authorize refuses the
-  // request with a 500 naming the missing middleware.
+  // cookies /auth/authorize set. Omit this and the app refuses to start.
   app.use(cookieParser());
 
   strategy.setHttpAdapter(app.getHttpAdapter());

--- a/docs/per-tool-authorization-oauth.md
+++ b/docs/per-tool-authorization-oauth.md
@@ -31,8 +31,15 @@ The OAuth authorization server ships as a separate package. Install it alongside
 `@rekog/mcp-nest`:
 
 ```bash
-npm install @rekog/mcp-nest-auth
+npm install @rekog/mcp-nest-auth cookie-parser
+npm install --save-dev @types/cookie-parser
 ```
+
+`cookie-parser` is not optional for the browser handshake: `/auth/authorize`
+sets the `oauth_session` and `oauth_state` cookies and `/auth/callback` reads
+them back off `req.cookies`. `McpAuthModule` does not register the middleware
+itself, so without `app.use(cookieParser())` the callback fails with
+`400 Missing OAuth session`.
 
 ## The wiring
 
@@ -44,6 +51,7 @@ with `cd examples/per-tool-authorization-oauth && npm install && npm start`:
 ```typescript
 import { Controller, Module, UseGuards } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
 import {
   McpHttpControllerFor,
   McpStrategy,
@@ -108,6 +116,12 @@ class AppModule {}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // OAuth session plumbing (NOT authentication): /auth/callback reads the
+  // cookies /auth/authorize set. Omit this and the callback 400s with
+  // "Missing OAuth session".
+  app.use(cookieParser());
+
   strategy.setHttpAdapter(app.getHttpAdapter());
   app.connectMicroservice({ strategy });
   await app.startAllMicroservices();

--- a/docs/server-examples.md
+++ b/docs/server-examples.md
@@ -249,8 +249,8 @@ npm install --save-dev @types/cookie-parser
 `cookie-parser` is required for the browser handshake: `/auth/authorize` sets the
 `oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back off
 `req.cookies`. `McpAuthModule` does not register the middleware itself, so
-without `app.use(cookieParser())` the authorization request fails fast with a
-500 whose message names the missing middleware.
+without `app.use(cookieParser())` the application refuses to start, with a
+bootstrap error naming the missing middleware.
 
 ```typescript
 import { Controller, UseGuards } from '@nestjs/common';

--- a/docs/server-examples.md
+++ b/docs/server-examples.md
@@ -242,11 +242,19 @@ Mount the MCP transport route as a real Nest controller (via `McpHttpControllerF
 If you use the built-in OAuth authorization server (`McpAuthModule`), install the auth package alongside `@rekog/mcp-nest`:
 
 ```bash
-npm install @rekog/mcp-nest-auth
+npm install @rekog/mcp-nest-auth cookie-parser
+npm install --save-dev @types/cookie-parser
 ```
+
+`cookie-parser` is required for the browser handshake: `/auth/authorize` sets the
+`oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back off
+`req.cookies`. `McpAuthModule` does not register the middleware itself, so
+without `app.use(cookieParser())` the authorization request fails fast with a
+500 whose message names the missing middleware.
 
 ```typescript
 import { Controller, UseGuards } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
 import { McpHttpControllerFor } from '@rekog/mcp-nest';
 import { AuthGuard } from './auth.guard';
 
@@ -274,6 +282,7 @@ class AppModule {}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.use(cookieParser()); // OAuth session plumbing — see the note above
   mcp.setHttpAdapter(app.getHttpAdapter());
   app.connectMicroservice({ strategy: mcp });
   await app.startAllMicroservices();

--- a/examples/azure-ad-oauth-provider/package.json
+++ b/examples/azure-ad-oauth-provider/package.json
@@ -14,6 +14,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "@rekog/mcp-nest": "file:../../packages/mcp-nest",
     "@rekog/mcp-nest-auth": "file:../../packages/mcp-nest-auth",
+    "cookie-parser": "^1.4.7",
     "jsonwebtoken": "^9.0.2",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
@@ -22,6 +23,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.8",
     "@types/jsonwebtoken": "^9.0.7",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/examples/azure-ad-oauth-provider/src/main.ts
+++ b/examples/azure-ad-oauth-provider/src/main.ts
@@ -79,9 +79,8 @@ async function bootstrap() {
 
   // Required by the REAL (Azure AD) handshake: /auth/authorize sets the
   // `oauth_session` + `oauth_state` cookies and /auth/callback reads them back
-  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and
-  // /auth/authorize refuses the request with a 500 naming this middleware.
-  // Session plumbing, not authentication.
+  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and the
+  // module refuses to finish booting. Session plumbing, not authentication.
   app.use(cookieParser());
 
   app.enableCors({ origin: true, credentials: true });

--- a/examples/azure-ad-oauth-provider/src/main.ts
+++ b/examples/azure-ad-oauth-provider/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { Controller, Module, UseGuards } from '@nestjs/common';
+import cookieParser from 'cookie-parser';
 import {
   McpHttpControllerFor,
   McpStrategy,
@@ -75,6 +76,14 @@ export class AppModule {}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Required by the REAL (Azure AD) handshake: /auth/authorize sets the
+  // `oauth_session` + `oauth_state` cookies and /auth/callback reads them back
+  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and
+  // /auth/authorize refuses the request with a 500 naming this middleware.
+  // Session plumbing, not authentication.
+  app.use(cookieParser());
+
   app.enableCors({ origin: true, credentials: true });
 
   mcp.setHttpAdapter(app.getHttpAdapter());

--- a/examples/azure-ad-provider/package.json
+++ b/examples/azure-ad-provider/package.json
@@ -16,6 +16,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "@rekog/mcp-nest": "file:../../packages/mcp-nest",
     "@rekog/mcp-nest-auth": "file:../../packages/mcp-nest-auth",
+    "cookie-parser": "^1.4.7",
     "jsonwebtoken": "^9.0.2",
     "passport-azure-ad-oauth2": "^0.0.4",
     "reflect-metadata": "^0.2.2",
@@ -24,6 +25,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.8",
     "@types/jsonwebtoken": "^9.0.7",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/examples/azure-ad-provider/src/main.ts
+++ b/examples/azure-ad-provider/src/main.ts
@@ -70,9 +70,8 @@ async function bootstrap() {
 
   // Required by the REAL (Azure AD) handshake: /auth/authorize sets the
   // `oauth_session` + `oauth_state` cookies and /auth/callback reads them back
-  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and
-  // /auth/authorize refuses the request with a 500 naming this middleware.
-  // Session plumbing, not authentication.
+  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and the
+  // module refuses to finish booting. Session plumbing, not authentication.
   app.use(cookieParser());
 
   app.enableCors({ origin: true, credentials: true });

--- a/examples/azure-ad-provider/src/main.ts
+++ b/examples/azure-ad-provider/src/main.ts
@@ -1,5 +1,6 @@
 import { Controller, Module, UseGuards } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
 import {
   McpHttpControllerFor,
   McpStrategy,
@@ -66,6 +67,14 @@ export class AppModule {}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Required by the REAL (Azure AD) handshake: /auth/authorize sets the
+  // `oauth_session` + `oauth_state` cookies and /auth/callback reads them back
+  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and
+  // /auth/authorize refuses the request with a 500 naming this middleware.
+  // Session plumbing, not authentication.
+  app.use(cookieParser());
+
   app.enableCors({ origin: true, credentials: true });
 
   mcp.setHttpAdapter(app.getHttpAdapter());

--- a/examples/per-tool-authorization-oauth/README.md
+++ b/examples/per-tool-authorization-oauth/README.md
@@ -26,9 +26,9 @@ The wiring is identical in both modes; only how the caller gets a JWT differs.
   - `app.use(cookieParser())` in `src/main.ts`. `/auth/authorize` sets the
     `oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back
     off `req.cookies`; `McpAuthModule` cannot register the middleware itself, so
-    without it `/auth/authorize` refuses the request with a 500 naming the
-    missing middleware (older versions got as far as the IdP and then failed the
-    callback with `400 Missing OAuth session`).
+    without it the server refuses to start, naming the missing middleware
+    (older versions booted fine and then failed the callback with
+    `400 Missing OAuth session`, after the user had already logged in).
   - The GitHub OAuth app's **Authorization callback URL** must be
     `$SERVER_URL/auth/callback` (e.g. `http://localhost:3013/auth/callback`), and
     its host must match `SERVER_URL` exactly — cookies set on `localhost` are not

--- a/examples/per-tool-authorization-oauth/README.md
+++ b/examples/per-tool-authorization-oauth/README.md
@@ -21,6 +21,18 @@ The wiring is identical in both modes; only how the caller gets a JWT differs.
   SERVER_URL=http://localhost:3013 PORT=3013 npm start
   ```
 
+  Two things the browser handshake needs beyond the env vars:
+
+  - `app.use(cookieParser())` in `src/main.ts`. `/auth/authorize` sets the
+    `oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back
+    off `req.cookies`; `McpAuthModule` does not register the middleware itself,
+    so without it the callback returns
+    `{"message":"Missing OAuth session","error":"Bad Request","statusCode":400}`.
+  - The GitHub OAuth app's **Authorization callback URL** must be
+    `$SERVER_URL/auth/callback` (e.g. `http://localhost:3013/auth/callback`), and
+    its host must match `SERVER_URL` exactly — cookies set on `localhost` are not
+    sent back to `127.0.0.1`.
+
 - **FAKE mode (offline, no external network)** — set `MCP_FAKE_AUTH=1`. The module
   is wired with dummy provider credentials (GitHub is only contacted during
   `/auth/authorize`, which is never hit), and identity comes from locally minted

--- a/examples/per-tool-authorization-oauth/README.md
+++ b/examples/per-tool-authorization-oauth/README.md
@@ -25,9 +25,10 @@ The wiring is identical in both modes; only how the caller gets a JWT differs.
 
   - `app.use(cookieParser())` in `src/main.ts`. `/auth/authorize` sets the
     `oauth_session` / `oauth_state` cookies and `/auth/callback` reads them back
-    off `req.cookies`; `McpAuthModule` does not register the middleware itself,
-    so without it the callback returns
-    `{"message":"Missing OAuth session","error":"Bad Request","statusCode":400}`.
+    off `req.cookies`; `McpAuthModule` cannot register the middleware itself, so
+    without it `/auth/authorize` refuses the request with a 500 naming the
+    missing middleware (older versions got as far as the IdP and then failed the
+    callback with `400 Missing OAuth session`).
   - The GitHub OAuth app's **Authorization callback URL** must be
     `$SERVER_URL/auth/callback` (e.g. `http://localhost:3013/auth/callback`), and
     its host must match `SERVER_URL` exactly — cookies set on `localhost` are not

--- a/examples/per-tool-authorization-oauth/package.json
+++ b/examples/per-tool-authorization-oauth/package.json
@@ -17,6 +17,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "@rekog/mcp-nest": "file:../../packages/mcp-nest",
     "@rekog/mcp-nest-auth": "file:../../packages/mcp-nest-auth",
+    "cookie-parser": "^1.4.7",
     "jsonwebtoken": "^9.0.2",
     "passport": "^0.7.0",
     "reflect-metadata": "^0.2.2",
@@ -25,6 +26,7 @@
     "zod": "^4.3.5"
   },
   "devDependencies": {
+    "@types/cookie-parser": "^1.4.8",
     "@types/jsonwebtoken": "^9.0.7",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/examples/per-tool-authorization-oauth/scripts/mint-jwts.ts
+++ b/examples/per-tool-authorization-oauth/scripts/mint-jwts.ts
@@ -7,5 +7,7 @@ const JWT_SECRET =
   process.env.JWT_SECRET || 'fake_local_dev_secret_at_least_32_chars_long';
 
 for (const [label, user] of Object.entries(FAKE_USERS)) {
-  console.log(`export ${label}='${mintFakeToken(user, JWT_SECRET, RESOURCE)}'`);
+  console.log(
+    `export ${label}='${mintFakeToken(user, JWT_SECRET, RESOURCE, SERVER_URL)}'`,
+  );
 }

--- a/examples/per-tool-authorization-oauth/src/main.ts
+++ b/examples/per-tool-authorization-oauth/src/main.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata';
 import { Controller, Module, UseGuards } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import cookieParser from 'cookie-parser';
 import {
   McpHttpControllerFor,
   McpStrategy,
@@ -83,6 +84,14 @@ class AppModule {}
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // Required by the REAL (GitHub) handshake: /auth/authorize sets the
+  // `oauth_session` + `oauth_state` cookies, and /auth/callback reads them back
+  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined and the
+  // callback fails with `400 Missing OAuth session`. This is session plumbing,
+  // not authentication.
+  app.use(cookieParser());
+
   strategy.setHttpAdapter(app.getHttpAdapter());
   app.connectMicroservice({ strategy });
   await app.startAllMicroservices();

--- a/examples/per-tool-authorization-oauth/src/main.ts
+++ b/examples/per-tool-authorization-oauth/src/main.ts
@@ -87,9 +87,9 @@ async function bootstrap() {
 
   // Required by the REAL (GitHub) handshake: /auth/authorize sets the
   // `oauth_session` + `oauth_state` cookies, and /auth/callback reads them back
-  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined and the
-  // callback fails with `400 Missing OAuth session`. This is session plumbing,
-  // not authentication.
+  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and
+  // /auth/authorize refuses the request with a 500 naming this middleware.
+  // Session plumbing, not authentication.
   app.use(cookieParser());
 
   strategy.setHttpAdapter(app.getHttpAdapter());

--- a/examples/per-tool-authorization-oauth/src/main.ts
+++ b/examples/per-tool-authorization-oauth/src/main.ts
@@ -87,9 +87,8 @@ async function bootstrap() {
 
   // Required by the REAL (GitHub) handshake: /auth/authorize sets the
   // `oauth_session` + `oauth_state` cookies, and /auth/callback reads them back
-  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and
-  // /auth/authorize refuses the request with a 500 naming this middleware.
-  // Session plumbing, not authentication.
+  // off `req.cookies`. Without cookie-parser `req.cookies` is undefined, and the
+  // module refuses to finish booting. Session plumbing, not authentication.
   app.use(cookieParser());
 
   strategy.setHttpAdapter(app.getHttpAdapter());

--- a/packages/mcp-nest-auth/src/mcp-oauth.controller.ts
+++ b/packages/mcp-nest-auth/src/mcp-oauth.controller.ts
@@ -6,6 +6,7 @@ import {
   Header,
   HttpCode,
   Inject,
+  InternalServerErrorException,
   Logger,
   Next,
   Post,
@@ -364,6 +365,34 @@ export function createMcpOAuthController(
       return await this.clientService.registerClient(registrationDto);
     }
 
+    /**
+     * `cookie-parser` is a hard requirement of the browser handshake, and nothing
+     * in this module can satisfy it: middleware belongs to the host
+     * application's bootstrap, so all we can do is notice and say so.
+     *
+     * Express leaves `req.cookies` as `undefined` when the middleware is absent
+     * — once mounted it always assigns at least `{}` — which is what makes this
+     * a reliable probe rather than a guess about an empty cookie jar. Without
+     * the check the misconfiguration surfaced as a bare
+     * `400 Missing OAuth session` from `/callback`, i.e. after the user had
+     * already been bounced through the IdP and with nothing pointing at the
+     * actual cause.
+     */
+    assertCookieParserMounted(req: { cookies?: unknown }) {
+      if (req.cookies !== undefined) {
+        return;
+      }
+      const message =
+        'cookie-parser is not mounted, so the OAuth session cookie cannot be read. ' +
+        'Add `app.use(cookieParser())` to your bootstrap (npm i cookie-parser ' +
+        '@types/cookie-parser). McpAuthModule stores the in-flight authorization ' +
+        'in the `oauth_session` / `oauth_state` cookies that the authorize endpoint ' +
+        'sets and the callback endpoint reads back; the module cannot register the ' +
+        'middleware for you. This is session plumbing, not authentication.';
+      this.logger.error(message);
+      throw new InternalServerErrorException(message);
+    }
+
     @Get(endpoints.authorize)
     async authorize(
       @Query() query: any,
@@ -461,6 +490,13 @@ export function createMcpOAuthController(
       // authorization code and the token claim all agree on what was actually
       // granted rather than on what was asked for.
       const grantedScope = this.scopePolicy.narrow(scope);
+
+      // Deliberately *after* request validation and *before* the session is
+      // minted: this is the first step that depends on cookies, so a
+      // misconfigured host still fails here — before the user is bounced to the
+      // IdP — without a missing middleware masking an invalid `client_id` or
+      // `redirect_uri` behind a 500 that isn't the caller's fault.
+      this.assertCookieParserMounted(req);
 
       // Create OAuth session
       const sessionId = randomBytes(32).toString('base64url');
@@ -571,6 +607,12 @@ export function createMcpOAuthController(
       if (!user) {
         throw new BadRequestException('Authentication failed');
       }
+
+      // Distinguishes "middleware absent" (a 500 naming the misconfiguration)
+      // from "cookie genuinely gone" — an expired session, a cleared jar, a
+      // callback replayed in a different browser — which stays a client-facing
+      // 400.
+      this.assertCookieParserMounted(req);
 
       const sessionId = req.cookies?.oauth_session;
       if (!sessionId) {
@@ -772,6 +814,8 @@ export function createMcpOAuthController(
       @Res() res: Response,
     ) {
       const parsed = this.parseRequestBody(body, req);
+
+      this.assertCookieParserMounted(req);
 
       const sessionId = req.cookies?.oauth_session as string | undefined;
       if (!sessionId) {

--- a/packages/mcp-nest-auth/src/mcp-oauth.module.ts
+++ b/packages/mcp-nest-auth/src/mcp-oauth.module.ts
@@ -14,6 +14,7 @@ import type {
 import { ClientIdMetadataService } from './services/client-id-metadata.service';
 import { ClientService } from './services/client.service';
 import { ConsentService } from './services/consent.service';
+import { CookieParserCheckService } from './services/cookie-parser-check.service';
 import { JwtTokenService } from './services/jwt-token.service';
 import { OAuthStrategyService } from './services/oauth-strategy.service';
 import { ScopePolicyService } from './services/scope-policy.service';
@@ -252,6 +253,10 @@ export class McpAuthModule {
       JwtTokenService,
       ScopePolicyService,
       McpAuthJwtGuard,
+      // Refuses to finish booting if the host forgot `app.use(cookieParser())`,
+      // so the omission cannot reach production as a callback that 400s after
+      // the user has already logged in at the IdP.
+      CookieParserCheckService,
     ];
 
     // No additional providers needed for TypeORM store - provider is created dynamically

--- a/packages/mcp-nest-auth/src/providers/oauth-provider.interface.ts
+++ b/packages/mcp-nest-auth/src/providers/oauth-provider.interface.ts
@@ -259,6 +259,18 @@ export interface OAuthUserModuleOptions {
   cookieSecure?: boolean;
   cookieMaxAge?: number;
 
+  /**
+   * Opt out of the bootstrap check that refuses to start the application when
+   * `cookie-parser` is not mounted.
+   *
+   * The check looks for the middleware by the name Express records for it, so
+   * it cannot see an equivalent parser mounted under another name — a wrapped
+   * or re-exported cookie-parser, `@fastify/cookie`, something hand-rolled.
+   * Set this when `req.cookies` is populated by such a means; the handshake
+   * itself only ever reads `req.cookies`, so it does not care what filled it.
+   */
+  skipCookieParserCheck?: boolean;
+
   // OAuth Session Configuration
   oauthSessionExpiresIn?: number; // in milliseconds
   authCodeExpiresIn?: number; // in milliseconds
@@ -367,4 +379,5 @@ export type OAuthModuleOptions = Required<
     // Optional fields that may remain undefined
     cookieSecure: boolean;
     storeConfiguration?: StoreConfiguration;
+    skipCookieParserCheck?: boolean;
   };

--- a/packages/mcp-nest-auth/src/services/cookie-parser-check.service.ts
+++ b/packages/mcp-nest-auth/src/services/cookie-parser-check.service.ts
@@ -1,0 +1,107 @@
+import {
+  Inject,
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+} from '@nestjs/common';
+import { HttpAdapterHost } from '@nestjs/core';
+import type { OAuthModuleOptions } from '../providers/oauth-provider.interface';
+
+/**
+ * The name Express records for a `cookie-parser()` middleware layer. The package
+ * returns a *named* function expression (`function cookieParser (req, res, next)`),
+ * so the name survives onto `layer.handle.name`.
+ */
+const COOKIE_PARSER_LAYER_NAME = 'cookieParser';
+
+export const COOKIE_PARSER_MISSING_MESSAGE =
+  'McpAuthModule requires cookie-parser, which is not mounted on this application. ' +
+  'Add `app.use(cookieParser())` to your bootstrap, before `app.listen()` ' +
+  '(npm i cookie-parser @types/cookie-parser).\n' +
+  'Why: the authorization handshake keeps its in-flight state in the `oauth_session` ' +
+  'and `oauth_state` cookies that /authorize sets and /callback reads back off ' +
+  '`req.cookies`, which Express only populates when cookie-parser is mounted. ' +
+  'Middleware belongs to the host application, so the module cannot register it for you. ' +
+  'This is session plumbing, not authentication.\n' +
+  'If you populate `req.cookies` by some other means, set `skipCookieParserCheck: true` ' +
+  'in McpAuthModule.forRoot() to silence this check.';
+
+/**
+ * Refuses to start an application that cannot complete the OAuth handshake.
+ *
+ * Nothing here can mount the middleware — `app.use()` belongs to the host's
+ * bootstrap — so the next best thing is to make the omission impossible to
+ * deploy. The failure it replaces was maximally deferred: discovery,
+ * registration and `/authorize` all succeeded, the user was bounced through a
+ * full IdP login, and only the callback failed, with a bare
+ * `400 Missing OAuth session` naming neither cause nor fix. A server that
+ * cannot authenticate anyone should not reach the point of accepting traffic.
+ *
+ * ### Why `onApplicationBootstrap`
+ *
+ * `NestFactory.create()` returns *before* any lifecycle hook runs, and hosts
+ * mount their middleware in that gap. Both `onModuleInit` and
+ * `onApplicationBootstrap` therefore observe a fully assembled middleware
+ * stack; this is the later of the two, so a host that mounts unusually late
+ * still passes.
+ *
+ * ### Why a name check, and what it costs
+ *
+ * Express exposes no "is this parser installed?" question, so the router stack
+ * is searched for the layer cookie-parser installs. The trade is a false
+ * positive when an equivalent parser is mounted under a different name — a
+ * wrapped or re-exported cookie-parser, `@fastify/cookie`, a hand-rolled
+ * parser. Because the consequence is a refusal to boot, that case gets an
+ * explicit way out (`skipCookieParserCheck`) rather than a silent pass, and
+ * anything we cannot introspect at all (a non-Express adapter, no router)
+ * declines to judge instead of guessing.
+ */
+@Injectable()
+export class CookieParserCheckService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(CookieParserCheckService.name);
+
+  constructor(
+    @Inject('OAUTH_MODULE_OPTIONS')
+    private readonly options: OAuthModuleOptions,
+    private readonly adapterHost: HttpAdapterHost,
+  ) {}
+
+  onApplicationBootstrap(): void {
+    if (this.options.skipCookieParserCheck) {
+      return;
+    }
+
+    const stack = this.getRouterStack();
+    // Undeterminable, not absent: a non-Express adapter or an app with no
+    // router yet. Refusing to boot on a guess would be worse than the late
+    // failure this check exists to prevent, and the request-time assertion in
+    // the controller still backstops it.
+    if (!stack) {
+      return;
+    }
+
+    const mounted = stack.some(
+      (layer) => layer?.handle?.name === COOKIE_PARSER_LAYER_NAME,
+    );
+    if (mounted) {
+      return;
+    }
+
+    this.logger.error(COOKIE_PARSER_MISSING_MESSAGE);
+    throw new Error(COOKIE_PARSER_MISSING_MESSAGE);
+  }
+
+  /**
+   * Express 4 keeps the router on `_router` and only creates it once something
+   * has been mounted; Express 5 exposes it as `router`. Anything else — a
+   * Fastify adapter, a mock — yields `undefined` and is treated as "cannot
+   * tell".
+   */
+  private getRouterStack():
+    | Array<{ handle?: { name?: string } }>
+    | undefined {
+    const instance: any = this.adapterHost?.httpAdapter?.getInstance?.();
+    const stack = instance?._router?.stack ?? instance?.router?.stack;
+    return Array.isArray(stack) ? stack : undefined;
+  }
+}

--- a/tests/mcp-multi-auth.e2e.spec.ts
+++ b/tests/mcp-multi-auth.e2e.spec.ts
@@ -8,6 +8,7 @@ import {
   Tool,
 } from '@rekog/mcp-nest';
 import { McpAuthModule } from '@rekog/mcp-nest-auth';
+import cookieParser from 'cookie-parser';
 import { z } from 'zod';
 
 const MockOAuthProviderA = {
@@ -167,6 +168,9 @@ describe('E2E: Multiple McpAuthModule instances', () => {
     // One HTTP adapter, but both strategies connect to it; each mounts its own
     // transports on its own distinct endpoints.
     const app: INestApplication = moduleFixture.createNestApplication();
+    // Required of every McpAuthModule host: the handshake routes are always
+    // mounted, and they read `req.cookies`.
+    app.use(cookieParser());
     strategyA.setHttpAdapter(app.getHttpAdapter());
     strategyB.setHttpAdapter(app.getHttpAdapter());
     app.connectMicroservice({ strategy: strategyA });

--- a/tests/mcp-oauth-auth.e2e.spec.ts
+++ b/tests/mcp-oauth-auth.e2e.spec.ts
@@ -690,20 +690,21 @@ describe.each(ERAS)('E2E: McpAuthModule OAuth Flow (%s era)', (era) => {
 
 /**
  * `cookie-parser` is the one piece of middleware `McpAuthModule` cannot install
- * for itself, and forgetting it used to fail three legs downstream: `/authorize`
- * happily redirected to the IdP, the user logged in, and only the callback threw
- * a bare `400 Missing OAuth session` that named neither the cause nor the fix.
+ * for itself, and forgetting it used to fail as late as an error can: discovery,
+ * registration and `/authorize` all succeeded, the user was bounced through a
+ * full IdP login, and only the callback answered — with a bare
+ * `400 Missing OAuth session` that named neither cause nor fix.
  *
- * Era-agnostic — the failure is in the authorization server's HTTP plumbing and
- * has nothing to do with the MCP protocol revision — so this deliberately sits
- * outside the `describe.each(ERAS)` block above.
+ * A server that cannot authenticate anyone should not start, so the omission is
+ * now a bootstrap failure. These tests pin that it happens at `app.init()`,
+ * before a single request is served.
+ *
+ * Era-agnostic — this is the authorization server's HTTP plumbing, nothing to do
+ * with the MCP protocol revision — so it sits outside `describe.each(ERAS)`.
  */
-describe('E2E: McpAuthModule without cookie-parser', () => {
-  let app: INestApplication;
-  let client: OAuthClient;
-
-  beforeAll(async () => {
-    const moduleFixture: TestingModule = await Test.createTestingModule({
+describe('E2E: McpAuthModule cookie-parser bootstrap check', () => {
+  const buildModule = (extraOptions: Record<string, unknown> = {}) =>
+    Test.createTestingModule({
       imports: [
         McpAuthModule.forRoot({
           provider: MockOAuthProvider,
@@ -714,73 +715,54 @@ describe('E2E: McpAuthModule without cookie-parser', () => {
           apiPrefix: 'auth',
           cookieSecure: false,
           storeConfiguration: { type: 'custom', store: new MockOAuthStore() },
+          ...extraOptions,
         }),
       ],
     }).compile();
 
-    // The whole point of this block: no `app.use(cookieParser())`.
-    app = moduleFixture.createNestApplication();
-    await app.init();
-
-    const response = await request(app.getHttpServer())
-      .post('/auth/register')
-      .send({
-        client_name: 'No Cookie Parser Client',
-        redirect_uris: ['http://localhost:8080/callback'],
-        grant_types: ['authorization_code'],
-        response_types: ['code'],
-      });
-    client = response.body;
-  });
-
-  afterAll(async () => {
+  it('refuses to start when cookie-parser is not mounted', async () => {
+    const app = (await buildModule()).createNestApplication();
+    // Deliberately no `app.use(cookieParser())`.
+    await expect(app.init()).rejects.toThrow(/cookie-parser/);
     await app.close();
   });
 
-  const authorizeUrl = (clientId: string, redirectUri: string) => {
-    const codeChallenge = createHash('sha256')
-      .update(randomBytes(32).toString('base64url'))
-      .digest('base64url');
-    return (
-      `/auth/authorize?response_type=code&client_id=${clientId}` +
-      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
-      `&code_challenge=${codeChallenge}&code_challenge_method=S256&state=s`
-    );
-  };
+  it('names the fix in the bootstrap error', async () => {
+    const app = (await buildModule()).createNestApplication();
 
-  it('fails the authorization request with a message naming the middleware', async () => {
-    const response = await request(app.getHttpServer())
-      .get(authorizeUrl(client.client_id, client.redirect_uris[0]))
-      .expect(500);
-
-    // The diagnosis a developer actually needs: what is missing, and the line
-    // that fixes it.
-    expect(response.body.message).toContain('cookie-parser');
-    expect(response.body.message).toContain('app.use(cookieParser())');
+    // The diagnosis a developer actually needs: the missing line, not just the
+    // missing concept.
+    await expect(app.init()).rejects.toThrow(/app\.use\(cookieParser\(\)\)/);
+    await app.close();
   });
 
-  it('fails before redirecting the user to the identity provider', async () => {
-    const response = await request(app.getHttpServer()).get(
-      authorizeUrl(client.client_id, client.redirect_uris[0]),
-    );
+  it('starts normally once cookie-parser is mounted', async () => {
+    const app = (await buildModule()).createNestApplication();
+    app.use(cookieParser());
 
-    // A 302 here would mean the user gets bounced through a full IdP login only
-    // to hit the wall on the way back — the behaviour this check exists to stop.
-    expect(response.status).not.toBe(302);
-    expect(response.headers.location).toBeUndefined();
-  });
+    await app.init();
 
-  it('still rejects an invalid client_id as a 400, not a 500', async () => {
-    // The misconfiguration must not shadow ordinary request validation: an
-    // unknown client is the caller's error and stays a 400.
+    // Reaching a served request at all is the assertion; the endpoint is
+    // incidental.
     await request(app.getHttpServer())
-      .get(authorizeUrl('invalid-client', 'http://localhost:8080/callback'))
-      .expect(400);
+      .get('/.well-known/oauth-authorization-server')
+      .expect(200);
+    await app.close();
   });
 
-  it('still rejects an unregistered redirect_uri as a 400, not a 500', async () => {
+  it('starts without cookie-parser when the check is opted out of', async () => {
+    // For hosts that populate `req.cookies` by other means — a wrapped or
+    // re-exported cookie-parser, @fastify/cookie — which the name-based probe
+    // cannot see. Refusing to boot those would be worse than the bug.
+    const app = (
+      await buildModule({ skipCookieParserCheck: true })
+    ).createNestApplication();
+
+    await app.init();
+
     await request(app.getHttpServer())
-      .get(authorizeUrl(client.client_id, 'http://evil.com/callback'))
-      .expect(400);
+      .get('/.well-known/oauth-authorization-server')
+      .expect(200);
+    await app.close();
   });
 });

--- a/tests/mcp-oauth-auth.e2e.spec.ts
+++ b/tests/mcp-oauth-auth.e2e.spec.ts
@@ -18,6 +18,7 @@ import {
   Tool,
 } from '@rekog/mcp-nest';
 import jwt from 'jsonwebtoken';
+import cookieParser from 'cookie-parser';
 import { McpAuthJwtGuard, McpAuthModule } from '@rekog/mcp-nest-auth';
 import { OAuthProviderConfig, OAuthUserProfile } from '@rekog/mcp-nest-auth';
 import type {
@@ -258,6 +259,11 @@ describe.each(ERAS)('E2E: McpAuthModule OAuth Flow (%s era)', (era) => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    // The authorization handshake keeps its in-flight state in cookies, so
+    // without this the flow cannot get past session creation. See the
+    // "missing cookie-parser" block at the bottom of this file for the
+    // deliberately unmounted counterpart.
+    app.use(cookieParser());
     strategy.setHttpAdapter(app.getHttpAdapter());
     app.connectMicroservice({ strategy });
 
@@ -679,5 +685,102 @@ describe.each(ERAS)('E2E: McpAuthModule OAuth Flow (%s era)', (era) => {
         })
         .expect(400);
     });
+  });
+});
+
+/**
+ * `cookie-parser` is the one piece of middleware `McpAuthModule` cannot install
+ * for itself, and forgetting it used to fail three legs downstream: `/authorize`
+ * happily redirected to the IdP, the user logged in, and only the callback threw
+ * a bare `400 Missing OAuth session` that named neither the cause nor the fix.
+ *
+ * Era-agnostic — the failure is in the authorization server's HTTP plumbing and
+ * has nothing to do with the MCP protocol revision — so this deliberately sits
+ * outside the `describe.each(ERAS)` block above.
+ */
+describe('E2E: McpAuthModule without cookie-parser', () => {
+  let app: INestApplication;
+  let client: OAuthClient;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        McpAuthModule.forRoot({
+          provider: MockOAuthProvider,
+          clientId: 'test-client-id',
+          clientSecret: 'test-client-secret',
+          jwtSecret: 'test-jwt-secret-that-is-at-least-32-characters-long',
+          serverUrl: 'http://localhost:3000',
+          apiPrefix: 'auth',
+          cookieSecure: false,
+          storeConfiguration: { type: 'custom', store: new MockOAuthStore() },
+        }),
+      ],
+    }).compile();
+
+    // The whole point of this block: no `app.use(cookieParser())`.
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    const response = await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        client_name: 'No Cookie Parser Client',
+        redirect_uris: ['http://localhost:8080/callback'],
+        grant_types: ['authorization_code'],
+        response_types: ['code'],
+      });
+    client = response.body;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const authorizeUrl = (clientId: string, redirectUri: string) => {
+    const codeChallenge = createHash('sha256')
+      .update(randomBytes(32).toString('base64url'))
+      .digest('base64url');
+    return (
+      `/auth/authorize?response_type=code&client_id=${clientId}` +
+      `&redirect_uri=${encodeURIComponent(redirectUri)}` +
+      `&code_challenge=${codeChallenge}&code_challenge_method=S256&state=s`
+    );
+  };
+
+  it('fails the authorization request with a message naming the middleware', async () => {
+    const response = await request(app.getHttpServer())
+      .get(authorizeUrl(client.client_id, client.redirect_uris[0]))
+      .expect(500);
+
+    // The diagnosis a developer actually needs: what is missing, and the line
+    // that fixes it.
+    expect(response.body.message).toContain('cookie-parser');
+    expect(response.body.message).toContain('app.use(cookieParser())');
+  });
+
+  it('fails before redirecting the user to the identity provider', async () => {
+    const response = await request(app.getHttpServer()).get(
+      authorizeUrl(client.client_id, client.redirect_uris[0]),
+    );
+
+    // A 302 here would mean the user gets bounced through a full IdP login only
+    // to hit the wall on the way back — the behaviour this check exists to stop.
+    expect(response.status).not.toBe(302);
+    expect(response.headers.location).toBeUndefined();
+  });
+
+  it('still rejects an invalid client_id as a 400, not a 500', async () => {
+    // The misconfiguration must not shadow ordinary request validation: an
+    // unknown client is the caller's error and stays a 400.
+    await request(app.getHttpServer())
+      .get(authorizeUrl('invalid-client', 'http://localhost:8080/callback'))
+      .expect(400);
+  });
+
+  it('still rejects an unregistered redirect_uri as a 400, not a 500', async () => {
+    await request(app.getHttpServer())
+      .get(authorizeUrl(client.client_id, 'http://evil.com/callback'))
+      .expect(400);
   });
 });

--- a/tests/mcp-oauth-security.e2e.spec.ts
+++ b/tests/mcp-oauth-security.e2e.spec.ts
@@ -585,6 +585,9 @@ describe('E2E: OAuth authorization security', () => {
       }).compile();
 
       app = moduleFixture.createNestApplication();
+      // Not incidental: importing McpAuthModule always mounts the handshake
+      // routes, so the bootstrap check requires this of every host.
+      app.use(cookieParser());
       await app.init();
     });
 


### PR DESCRIPTION
## The bug

Running `examples/per-tool-authorization-oauth` in REAL (GitHub) mode fails at the last leg of the handshake:

```json
{"message":"Missing OAuth session","error":"Bad Request","statusCode":400}
```

Discovery, client registration and `/auth/authorize` all succeed — the failure lands after the IdP round-trip, on `/auth/callback`.

## Root cause

`/auth/authorize` sets `oauth_session` + `oauth_state` cookies; the callback reads them back off `req.cookies`. Express only populates `req.cookies` when `cookie-parser` is mounted, and `McpAuthModule` registers no middleware of its own — middleware belongs to the host's bootstrap. So `req.cookies` is `undefined` and the callback 400s.

The affected examples were only ever verified in FAKE mode, which never reaches `/auth/callback`.

**Scope:** core (`packages/mcp-nest`) has zero cookie references — unaffected. Within `mcp-nest-auth`, only the browser legs are affected; Bearer-token paths read the `Authorization` header.

## Fail at boot, not on the first request

The omission is now a **bootstrap failure**: a server that cannot complete the handshake cannot authenticate anyone and should not accept traffic. This mirrors the reasoning the module already applies to the CIMD-without-consent combination, which is likewise a boot failure rather than a quietly missing security property.

`CookieParserCheckService` runs on `onApplicationBootstrap` and throws unless the middleware is on the router stack.

- **Why that hook:** `NestFactory.create()` returns *before* any lifecycle hook fires, and hosts mount middleware in exactly that gap. Verified empirically that both `onModuleInit` and `onApplicationBootstrap` observe `app.use(cookieParser())`; the later of the two is used so an unusually late mount still passes.
- **Why a name match, and what it costs:** Express exposes no way to ask whether a parser is installed, so the router stack is searched for the layer cookie-parser installs. That misjudges an equivalent parser mounted under a different name — a wrapped or re-exported cookie-parser, `@fastify/cookie`. Since the consequence is a refusal to boot, that case gets an explicit `skipCookieParserCheck: true` rather than a silent pass. Anything not introspectable at all (non-Express adapter, no router) declines to judge instead of guessing.
- The request-time assertion in the controller remains as a backstop for those opt-out paths, and upgrades the old bare `400 Missing OAuth session`.

The requirement is universal for hosts of this module: `disableEndpoints` covers only the well-known routes and `/register`, so `/authorize` and `/callback` are **always** mounted. Two test apps that never ran the handshake were relying on that not being enforced; they are now wired correctly.

## Sweep

All four examples and all six docs wiring `McpAuthModule` were audited:

| | before | now |
|---|---|---|
| `examples/per-tool-authorization-oauth` | broken | fixed |
| `examples/azure-ad-provider` | broken | fixed |
| `examples/azure-ad-oauth-provider` | broken | fixed |
| `examples/built-in-authorization-server` | ok | ok |
| `docs/built-in-authorization-server.md` | ok | troubleshooting + options table |
| `docs/per-tool-authorization-oauth.md` | missing | documented |
| `docs/azure-ad-provider.md` | missing | documented |
| `docs/azure-ad-oauth-provider.md` | missing | documented |
| `docs/server-examples.md` | missing | documented |
| `docs/migration-to-v2.md` | cited `cookieParser` as an example of *unrelated* middleware | corrected — it is required |

`docs/external-authorization-server.md` and `docs/README.md` only mention the module in prose, no wiring — left alone.

## Verification

- **851 tests pass, 0 fail.**
- New bootstrap-check block in `tests/mcp-oauth-auth.e2e.spec.ts`: refuses to start without the middleware, names the fix in the error, starts normally once mounted, and starts when opted out via `skipCookieParserCheck`.
- That spec's main app now mounts `cookieParser()` — its authorize tests accepted `[302, 500]` and were passing without ever exercising session creation.
- End-to-end on the real example: with the middleware removed the process **exits 1** from `onApplicationBootstrap`, `listen()` is never reached and the port stays free; restored, it boots and serves `200`.
- Both azure examples typecheck; `azure-ad-provider` verified returning 302 to `login.windows.net` with both `Set-Cookie` headers.
- The browser login leg itself still needs a human and was not automated.

## Also

- Docs note the IdP callback URL must match `serverUrl` host-for-host — cookies set on `localhost` are not sent to `127.0.0.1`.
- Drive-by, unrelated: `examples/per-tool-authorization-oauth/scripts/mint-jwts.ts` did not compile (`mintFakeToken` gained an `issuer` param; the script still passed three args), so the README's `npm run mint` was broken. Fixed and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJXhjcfkFSdHBEpG8DJtMo
