### PR TITLE
fix(tools/call): stop stringifying input_required (MRTR) results

### DIFF
--- a/packages/mcp-nest/src/mcp/transport/mcp.strategy.ts
+++ b/packages/mcp-nest/src/mcp/transport/mcp.strategy.ts
@@ -8,6 +8,7 @@ import {
 import {
   McpServer,
   GetPromptResult,
+  isInputRequiredResult,
   ListToolsResult,
   ProtocolError,
   PromptArgument,
@@ -801,6 +802,9 @@ export class McpStrategy extends Server implements CustomTransportStrategy {
     result: any,
     outputSchema?: ToolInputSchema,
   ): Promise<any> {
+    if (isInputRequiredResult(result)) {
+      return result;
+    }
     if (result && typeof result === 'object' && Array.isArray(result.content)) {
       return result;
     }

--- a/tests/mcp-modern-era.e2e.spec.ts
+++ b/tests/mcp-modern-era.e2e.spec.ts
@@ -9,6 +9,7 @@ import { Controller, Injectable } from '@nestjs/common';
 import { Ctx, Payload } from '@nestjs/microservices';
 import { Client } from '@modelcontextprotocol/client';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
+import { inputRequired } from '@modelcontextprotocol/server';
 import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 import { z } from 'zod';
 import {
@@ -77,6 +78,15 @@ class ModernCapabilities {
         },
       ],
     };
+  }
+
+  @Tool({
+    name: 'needs-input',
+    description: 'Asks the client for more input via MRTR',
+    parameters: z.object({}),
+  })
+  needsInput() {
+    return inputRequired({ requestState: 'pending' });
   }
 
   @Resource({
@@ -210,6 +220,7 @@ describe('modern era — capabilities', () => {
     const tools = await client.listTools();
     expect(tools.tools.map((t: any) => t.name).sort()).toEqual([
       'greet',
+      'needs-input',
       'talk',
       'whoami',
       'work',
@@ -221,6 +232,28 @@ describe('modern era — capabilities', () => {
     });
     expect(result.content[0].text).toBe('Hello, rinor!');
     await client.close();
+  });
+
+  it('returns an input_required result untouched (MRTR)', async () => {
+    const { status, json } = await rawPost(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'needs-input', arguments: {}, _meta: envelope },
+      },
+      {
+        'MCP-Protocol-Version': MODERN,
+        'Mcp-Method': 'tools/call',
+        'Mcp-Name': 'needs-input',
+      },
+    );
+
+    expect(status).toBe(200);
+    // Must stay a structured input_required result, not stringified content.
+    expect(json.result.resultType).toBe('input_required');
+    expect(json.result.requestState).toBe('pending');
+    expect(json.result.content).toBeUndefined();
   });
 
   it('serves resources, resource templates and prompts', async () => {


### PR DESCRIPTION
`formatToolResult` only recognized the legacy `CallToolResult` shape (an object with a `content` array). An `input_required` result from `inputRequired(...)` has no `content`, so it fell into the fallback branch and got `JSON.stringify`'d into a text block — silently discarding `resultType`, `inputRequests`, and `requestState`. This breaks [MRTR](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr) for any tool call.

`resources/read` and `prompts/get` aren't affected since they don't go through this formatter.

Fix: check `isInputRequiredResult(result)` (the SDK's own type guard) before the existing `content` check, and return it untouched.

Added a test in `mcp-modern-era.e2e.spec.ts` for a tool returning `inputRequired({ requestState: 'pending' })`, confirmed it fails without the fix and passes with it. Full suite still passes (870/870).
